### PR TITLE
xy-output-component: check line chart reference before accessing it

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/components/xy-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/xy-output-component.tsx
@@ -56,7 +56,9 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         if (prevProps.style.chartWidth !== this.props.style.chartWidth) {
             this.updateXY();
         }
-        this.lineChartRef.current.chartInstance.render();
+        if (this.lineChartRef.current) {
+            this.lineChartRef.current.chartInstance.render();
+        }
     }
 
     renderTree(): React.ReactNode {


### PR DESCRIPTION
Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>