### PR TITLE
timegraph-output-component: fix synchronization bug

### DIFF
--- a/viewer-prototype/src/browser/style/output-components-style.css
+++ b/viewer-prototype/src/browser/style/output-components-style.css
@@ -46,6 +46,8 @@
 #timegraph-main {
     width: 100%;
     display: flex;
+    overflow-y: scroll;
+    position: relative;
 }
 
 #main {

--- a/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
@@ -6,16 +6,34 @@ import { Entry, EntryHeader } from 'tsp-typescript-client/lib/models/entry';
 
 
 export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
+    protected treeRef = React.createRef<any>();
+    protected chartRef = React.createRef<any>();
+    
     renderMainArea(): React.ReactNode {
         const treeWidth = this.props.style.width - this.props.style.chartWidth - this.getHandleWidth();
         return <React.Fragment>
-            <div className='output-component-tree' style={{ width: treeWidth, height: this.props.style.height }}>
+            <div 
+                ref={this.treeRef} 
+                className='output-component-tree' 
+                style={{ width: treeWidth, height: this.props.style.height }}
+                onScroll={event => {event.persist(); this.scrollSync(this.treeRef)}}
+            >
                 {this.renderTree()}
             </div>
             <div className='output-component-chart' style={{ width: this.props.style.chartWidth, backgroundColor: '#3f3f3f' }}>
                 {this.renderChart()}
             </div>
         </React.Fragment>;
+    }
+
+    scrollSync(scrolledElement: React.RefObject<any>) {
+        let treeElement = this.treeRef.current;
+        let chartElement = this.chartRef.current;
+        if (scrolledElement === this.treeRef) {
+            chartElement.scrollTop = scrolledElement.current.scrollTop;
+        } else {
+            treeElement.scrollTop = scrolledElement.current.scrollTop;
+        }
     }
 
     abstract renderTree(): React.ReactNode;

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/timegraph-container-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/timegraph-container-component.tsx
@@ -29,6 +29,6 @@ export class ReactTimeGraphContainer extends React.Component<ReactTimeGraphConta
     }
 
     render() {
-        return <canvas ref={ref => this.ref = ref || undefined} onWheel={e => e.preventDefault()}></canvas>
+        return <canvas ref={ref => this.ref = ref || undefined} ></canvas>
     }
 }


### PR DESCRIPTION
Fix visible in trace explorer with analysis "Thread Status", entries are same height as lines and both components (tree and chart) scroll at the same time.
Works for Chrome but Firefox has resize problem. 
Also experienced line height problems (lines too big and blurry) with a few browsers but don't know the cause.
![height-problem](https://user-images.githubusercontent.com/17573271/77465842-ac0eb100-6ddf-11ea-8aed-ec4dea7aaabb.jpg)
![normal-view](https://user-images.githubusercontent.com/17573271/77465844-aca74780-6ddf-11ea-9717-d93370e21103.png)

