### PR TITLE
Add support of experiments consisting of 1 or more traces

### DIFF
--- a/viewer-prototype/package.json
+++ b/viewer-prototype/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@theia/core": "next",
     "@theia/editor": "next",
+    "@theia/filesystem": "next",
     "chart.js": "^2.8.0",
     "react-chartjs-2": "^2.7.6",
     "ag-grid-community": "^20.2.0",

--- a/viewer-prototype/src/browser/style/trace-explorer.css
+++ b/viewer-prototype/src/browser/style/trace-explorer.css
@@ -79,6 +79,7 @@
 .trace-element-path, .outputs-element-description {
     color: var(--theia-ui-font-color2);
     /* color: rgb(160, 160, 160); */
+    white-space: pre;
 }
 
 .trace-element-options {

--- a/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
@@ -38,4 +38,11 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
             outputStatus: xyTreeResponse.status
         });
     }
+
+    componentWillUnmount() {
+        // fix Warning: Can't perform a React state update on an unmounted component
+        this.setState = (state,callback)=>{
+            return;
+        };
+    }
 }

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -7,7 +7,7 @@ import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 export namespace TraceViewerCommands {
     export const OPEN: Command = {
         id: 'trace:open',
-        label: 'Open Trace'
+        label: 'Open Trace(s)'
     };
 }
 
@@ -20,7 +20,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     }
 
     readonly id = TraceViewerWidget.ID;
-    readonly label = 'Open trace';
+    readonly label = TraceViewerCommands.OPEN.label;
 
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(TraceViewerCommands.OPEN);

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -17,12 +17,14 @@ import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-cont
 import { TRACE_EXPLORER_ID, TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TraceManager } from '../../common/trace-manager';
+import { ExperimentManager } from '../../common/experiment-manager';
 // import { TracePropertiesContribution } from '../trace-properties-view/trace-properties-view-contribution';
 // import { TracePropertiesWidget, TRACE_PROPERTIES_ID } from '../trace-properties-view/trace-properties-view-widget';
 
 export default new ContainerModule(bind => {
     bind(TspClient).toDynamicValue(() => new TspClient('http://localhost:8080/tsp/api')).inSingletonScope();
     bind(TraceManager).toSelf().inSingletonScope();
+    bind(ExperimentManager).toSelf().inSingletonScope();
 
     bind(TraceViewerWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -1,4 +1,5 @@
 import { Path } from '@theia/core';
+import { FileSystem, FileStat } from '@theia/filesystem/lib/common/filesystem';
 import { Message, StatusBar } from '@theia/core/lib/browser';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { inject, injectable } from 'inversify';
@@ -7,8 +8,11 @@ import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descri
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TraceManager } from '../../common/trace-manager';
+import { ExperimentManager } from '../../common/experiment-manager';
 import { OutputAddedSignalPayload, TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TraceContextComponent } from './components/trace-context-component';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import URI from '@theia/core/lib/common/uri';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -21,7 +25,7 @@ export class TraceViewerWidget extends ReactWidget {
     static LABEL = 'Trace Viewer';
 
     protected readonly uri: Path;
-    private openedTrace: Trace | undefined;
+    private openedExperiment: Experiment | undefined;
     private outputDescriptors: OutputDescriptor[] = [];
 
     private resizeHandlers: (() => void)[] = [];
@@ -32,8 +36,10 @@ export class TraceViewerWidget extends ReactWidget {
     constructor(
         @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions,
         @inject(TraceManager) private traceManager: TraceManager,
+        @inject(ExperimentManager) private experimentManager: ExperimentManager,
         @inject(TspClient) private tspClient: TspClient,
-        @inject(StatusBar) private statusBar: StatusBar
+        @inject(StatusBar) private statusBar: StatusBar,
+        @inject(FileSystem) private readonly fileSystem: FileSystem,
     ) {
         super();
         this.uri = new Path(this.options.traceURI);
@@ -46,16 +52,55 @@ export class TraceViewerWidget extends ReactWidget {
     }
 
     async initialize(): Promise<void> {
-        const trace = await this.traceManager.openTrace(this.uri, this.uri.name);
-        if (trace) {
-            this.openedTrace = trace;
+
+        /*
+         * TODO: use backend service to find traces
+         */
+        let tracesArray = new Array<Path>();
+        const fileStat = await this.fileSystem.getFileStat(this.uri.toString());
+        if (fileStat) {
+            if (fileStat.isDirectory) {
+                // Find recursivly CTF traces
+                await this.findTraces(fileStat, tracesArray);
+            } else {
+                // Open single trace file 
+                tracesArray.push(this.uri);
+            }
         }
+
+        let traces = new Array<Trace>();
+
+        for (let i = 0; i < tracesArray.length; i++) {
+            const trace = await this.traceManager.openTrace(tracesArray[i], tracesArray[i].name);
+            if (trace) {
+                traces.push(trace);
+            }
+        }
+
+        const experiment = await this.experimentManager.openExperiment(this.uri.name, traces);
+        if (experiment) {
+            this.openedExperiment = experiment;
+        }
+
         this.update();
     }
 
     onCloseRequest(msg: Message) {
-        if (this.openedTrace) {
-            this.traceManager.closeTrace(this.openedTrace.UUID);
+        if (this.openedExperiment) {
+
+            let traces = this.openedExperiment.traces;
+            // Close experiment
+            this.experimentManager.closeExperiment(this.openedExperiment.UUID);
+
+            /*
+             TODO: 
+             Decide wheather to delete traces from server as well.
+             Other experiments might wan to be create with these traces.
+            */
+            // Close each trace
+            for (let i = 0; i < traces.length; i++) {
+                this.traceManager.closeTrace(traces[i].UUID);
+            }
         }
         this.statusBar.removeElement('time-selection-range');
         super.onCloseRequest(msg);
@@ -68,7 +113,7 @@ export class TraceViewerWidget extends ReactWidget {
     protected render(): React.ReactNode {
         this.onOutputRemoved = this.onOutputRemoved.bind(this);
         return <div className='trace-viewer-container'>
-            {this.openedTrace ? <TraceContextComponent trace={this.openedTrace}
+            {this.openedExperiment ? <TraceContextComponent experiment={this.openedExperiment}
                 tspClient={this.tspClient}
                 outputs={this.outputDescriptors}
                 onOutputRemove={this.onOutputRemoved}
@@ -78,7 +123,7 @@ export class TraceViewerWidget extends ReactWidget {
     }
 
     private onOutputAdded(payload: OutputAddedSignalPayload) {
-        if (this.openedTrace && payload.getTrace().UUID === this.openedTrace.UUID) {
+        if (this.openedExperiment && payload.getExperiment().UUID === this.openedExperiment.UUID) {
             const exist = this.outputDescriptors.find(output => { return output.id === payload.getOutputDescriptor().id });
             if (!exist) {
                 this.outputDescriptors.push(payload.getOutputDescriptor());
@@ -93,5 +138,42 @@ export class TraceViewerWidget extends ReactWidget {
         });
         this.outputDescriptors = outputToKeep;
         this.update();
+    }
+
+    /*
+     * TODO: use backend service to find traces
+     */
+    private async findTraces(rootStat: FileStat | undefined, traces: Array<Path>) {
+        /**
+         * If single file selection then return single trace in traces, if directory then find
+         * recoursivly CTF traces in starting from root directory.
+         */
+        if (rootStat) {
+            if (rootStat.isDirectory) {
+                    let isCtf = this.isCtf(rootStat);
+                if (isCtf) {
+                    let uri = new URI(rootStat.uri);
+                    traces.push(uri.path);
+                } else {
+                    if (rootStat.children) {
+                        for (let i = 0; i < rootStat.children.length; i++) {
+                            const fileStat = await this.fileSystem.getFileStat(rootStat.children[i].uri);
+                            await this.findTraces(fileStat, traces);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    private isCtf(stat: FileStat): Boolean {
+        if (stat.children) {
+            for (let i = 0; i < stat.children.length; i++) {
+                let path = new Path(stat.children[i].uri);
+                if (path.name === "metadata") {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/viewer-prototype/src/common/experiment-manager.ts
+++ b/viewer-prototype/src/common/experiment-manager.ts
@@ -1,0 +1,141 @@
+import { Trace } from 'tsp-typescript-client/lib/models/trace';
+import { Emitter } from '@theia/core';
+import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { Query } from 'tsp-typescript-client/lib/models/query/query';
+import { injectable, inject } from 'inversify';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+
+@injectable()
+export class ExperimentManager {
+    // Open signal
+    private experimentOpenedEmitter = new Emitter<Experiment>();
+    public experimentOpenedSignal = this.experimentOpenedEmitter.event;
+
+    // Close signal
+    private experimentClosedEmitter = new Emitter<Experiment>();
+    public experimentClosedSignal = this.experimentClosedEmitter.event;
+
+    private fOpenExperiments: Map<string, Experiment> = new Map();;
+
+    private constructor(
+        @inject(TspClient) private tspClient: TspClient
+    ) { }
+
+    /**
+     * Get an array of opened experiments
+     * @returns Array of experiment
+     */
+    async getOpenedExperiments(): Promise<Experiment[]> {
+        const openedExperiments: Array<Experiment> = new Array();
+        // Look on the server for opened experiments
+        const experimentResponse = await this.tspClient.fetchExperiments();
+        if (experimentResponse.isOk()) {
+            openedExperiments.push(...experimentResponse.getModel());
+        }
+        return openedExperiments;
+    }
+
+    /**
+     * Get a specific experiment information
+     * @param experimentUUID experiment UUID
+     */
+    async getExperiment(experimentUUID: string): Promise<Experiment | undefined> {
+        // Check if the experiment is in "cache"
+        let experiment = this.fOpenExperiments.get(experimentUUID);
+
+        // If the experiment is undefined, check on the server
+        if (!experiment) {
+            const experimentResponse = await this.tspClient.fetchExperiment(experimentUUID);
+            if (experimentResponse.isOk()) {
+                experiment = experimentResponse.getModel();
+            }
+        }
+        return experiment;
+    }
+
+    /**
+     * Get an array of OutputDescriptor for a given experiment
+     * @param experimentUUID experiment UUID
+     */
+    async getAvailableOutputs(experimentUUID: string): Promise<OutputDescriptor[] | undefined> {
+        // Check if the experiment is opened
+        const experiment = this.fOpenExperiments.get(experimentUUID);
+        if (experiment) {
+            const outputsResponse = await this.tspClient.experimentOutputs(experiment.UUID);
+            return outputsResponse.getModel();
+        }
+        return undefined;
+    }
+
+    /**
+     * Open a given experiment on the server
+     * @param experimentURI experiment URI to open
+     * @param experimentName Optional name for the experiment. If not specified the URI name is used
+     * @returns The opened experiment
+     */
+    async openExperiment(experimentName: string, traces: Array<Trace>): Promise<Experiment | undefined> {
+        let name = experimentName;
+
+        let traceURIs = new Array<String>();
+        for (let i = 0; i < traces.length; i++) {
+            traceURIs.push(traces[i].UUID);
+        }
+
+        const experimentResponse = await this.tspClient.createExperiment(new Query({
+            'name': name,
+            'traces': traceURIs
+        }));
+        const experiment = experimentResponse.getModel()
+        if (experiment && (experimentResponse.isOk() || experimentResponse.getStatusCode() === 409)) {
+            this.addExperiment(experiment);
+            this.experimentOpenedEmitter.fire(experiment);
+            return experiment;
+        }
+        return undefined;
+    }
+
+    /**
+     * Update the experiment with the latest info from the server.
+     * @param experimentName experiment name to update
+     * @returns The updated experiment or undefined if the experiment was not open previously
+     */
+    async updateExperiment(experimentUUID: string): Promise<Experiment | undefined> {
+        const currentExperiment = this.fOpenExperiments.get(experimentUUID);
+        if (currentExperiment) {
+            const experimentResponse = await this.tspClient.fetchExperiment(currentExperiment.UUID);
+            const experiment = experimentResponse.getModel();
+            if (experiment && experimentResponse.isOk) {
+                this.fOpenExperiments.set(experimentUUID, experiment);
+                return experiment;
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Close the given on the server
+     * @param experimentUUID experiment UUID
+     */
+    async closeExperiment(experimentUUID: string) {
+        const experimentToClose = this.fOpenExperiments.get(experimentUUID);
+        if (experimentToClose) {
+            await this.tspClient.deleteExperiment(experimentUUID);
+            const deletedExperiment = this.removeExperiment(experimentUUID);
+            if (deletedExperiment) {
+                this.experimentClosedEmitter.fire(deletedExperiment);
+            }
+        }
+    }
+
+    private addExperiment(experiment: Experiment) {
+        this.fOpenExperiments.set(experiment.UUID, experiment);
+    }
+
+    private removeExperiment(experimentUUID: string): Experiment | undefined {
+        const deletedExperiment = this.fOpenExperiments.get(experimentUUID);
+        this.fOpenExperiments.delete(experimentUUID);
+        return deletedExperiment;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,7 +4203,7 @@ debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.5.1, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4360,7 +4360,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -5953,7 +5953,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5991,13 +5991,6 @@ ignore-loader@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
   integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -7702,15 +7695,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -7815,22 +7799,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.50:
   version "1.1.52"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.52.tgz#bcffee3e0a758e92e44ecfaecd0a47554b0bcba9"
@@ -7919,27 +7887,6 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
@@ -7954,7 +7901,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -9148,7 +9095,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.1.6, rc@^1.2.1, rc@^1.2.7:
+rc@^1.1.6, rc@^1.2.1:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -9819,7 +9766,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@^1.2.4, sax@~1.2.1:
+sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -9875,7 +9822,7 @@ semantic-ui-react@^0.86.0:
     react-is "^16.7.0"
     shallowequal "^1.1.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10563,7 +10510,7 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4.0.0, tar@^4.4.12, tar@^4.4.2:
+tar@^4.0.0, tar@^4.4.12:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
- Added support of opening single and multiple traces in an experiment
- Upload each trace and create experiment using ExperimentManager
- Implemented simple trace detection algorithm. If the selection is a
directory, then the files system is recursively searched for CTF traces
by finding the metadata file. Otherwise a single file is opened as trace
- The detection of traces is done in the front-end. This needs to be
replaced by a backend service that avoids querying the file system
directly from the frontend.
- Updated class, method and variable names to reflect support of
experiments
- Update Trace Explorer to show available experiments and it's traces.
This visualized list is very basic and needs to be improved.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>