### PR TITLE
Handle conflicting experiments when opening

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -80,6 +80,7 @@ export class TraceViewerWidget extends ReactWidget {
         const experiment = await this.experimentManager.openExperiment(this.uri.name, traces);
         if (experiment) {
             this.openedExperiment = experiment;
+            this.title.label = 'Trace: ' + experiment.name;
         }
 
         this.update();

--- a/viewer-prototype/src/common/trace-manager.ts
+++ b/viewer-prototype/src/common/trace-manager.ts
@@ -4,6 +4,7 @@ import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { Query } from 'tsp-typescript-client/lib/models/query/query';
 import { injectable, inject } from 'inversify';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
 
 @injectable()
 export class TraceManager {
@@ -89,6 +90,27 @@ export class TraceManager {
             this.addTrace(trace);
             this.traceOpenedEmitter.fire(trace);
             return trace;
+        } else if (trace && traceResponse.getStatusCode() === 409) {
+            // Repost with a suffix as long as there are conflicts
+            let handleConflict = async function(tspClient: TspClient, tryNb: number): Promise<TspClientResponse<Trace>> {
+                let suffix = '(' + tryNb + ')';
+                return await tspClient.openTrace(new Query({
+                    'name': name + suffix,
+                    'uri': tracePath
+                }))
+            }
+            let conflictResolutionResponse = traceResponse;
+            let i = 1;
+            while (conflictResolutionResponse.getStatusCode() === 409) {
+                conflictResolutionResponse = await handleConflict(this.tspClient, i);
+                i++;
+            }
+            const trace = conflictResolutionResponse.getModel()
+            if (trace && conflictResolutionResponse.isOk()) {
+                this.addTrace(trace);
+                this.traceOpenedEmitter.fire(trace);
+                return trace;
+            }
         }
         // TODO Handle trace open errors
         return undefined;

--- a/viewer-prototype/src/common/trace-manager.ts
+++ b/viewer-prototype/src/common/trace-manager.ts
@@ -85,11 +85,12 @@ export class TraceManager {
             'uri': tracePath
         }));
         const trace = traceResponse.getModel()
-        if (trace && (traceResponse.isOk() || traceResponse.getStatusCode() === 409)) {
+        if (trace && traceResponse.isOk()) {
             this.addTrace(trace);
             this.traceOpenedEmitter.fire(trace);
             return trace;
         }
+        // TODO Handle trace open errors
         return undefined;
     }
 


### PR DESCRIPTION
When opening a trace with the same name as another experiment, the experiment
that contains it will have a conflict on the server. The client should
retry posting it with a different name until it succeeds or another
error occurs.

The title of the trace viewer should also be updated to represent the
actual name of the experiment.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>