### PR TITLE
Update example apps to support open-vsx, support C/C++ with vscode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ node_modules
 .browser_modules
 lib
 *.log
+sample-traces
+trace-compass-server
+trace-compass-server.tar.gz
+tracecompass-test-traces
 *-app/*
 !*-app/package.json
 !*-app/electron-builder.yml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ lib
 *.log
 *-app/*
 !*-app/package.json
+!*-app/electron-builder.yml
+!*-app/resources/
+!*-app/scripts

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,23 @@
+FROM gitpod/workspace-full-vnc:latest
+
+# Docker build does not rebuild an image when a base image is changed, increase this counter to trigger it.
+ENV TRIGGER_REBUILD 3
+
+# Install custom tools, runtime, etc.
+RUN sudo apt-get update \
+    # window manager
+    && sudo apt-get install -y jwm \
+    # electron
+    && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 \
+    # native-keymap
+    && sudo apt-get install -y libx11-dev libxkbfile-dev \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Pin Node.js to v10.
+ENV NODE_VERSION="10.21.0"
+RUN bash -c ". .nvm/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && npm install -g yarn"
+ENV PATH=$HOME/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,14 +6,22 @@ ports:
   onOpen: ignore
 - port: 9339 # Node.js debug port
   onOpen: ignore
-- port: 6080
+- port: 6080 # VNC server
   onOpen: ignore
 - port: 5900
   onOpen: ignore
+- port: 8080 # Trace Compass server
+  onOpen: ignore
 tasks:
-- init: yarn
+- init: >
+    yarn download:server
   command: >
-    yarn start:browser ../ --hostname=0.0.0.0
+    yarn start:server
+- init: >
+    yarn download:sample-traces &&
+    yarn
+  command: >
+    yarn start:electron ../sample-traces/ --hostname=0.0.0.0
 github:
   prebuilds:
     pullRequestsFromForks: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,19 @@
+image:
+  file: .gitpod.dockerfile
+ports:
+- port: 3000 # Trace viewer example application
+- port: 9229 # Node.js debug port
+  onOpen: ignore
+- port: 9339 # Node.js debug port
+  onOpen: ignore
+- port: 6080
+  onOpen: ignore
+- port: 5900
+  onOpen: ignore
+tasks:
+- init: yarn
+  command: >
+    yarn start:browser ../ --hostname=0.0.0.0
+github:
+  prebuilds:
+    pullRequestsFromForks: true

--- a/LICENSE.gitpod.md
+++ b/LICENSE.gitpod.md
@@ -1,0 +1,14 @@
+The Gitpod config files have been copied from the main eclipse-theia repo:
+
+[.gitpod.yml](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.yml)
+
+[.gitpod.dockerfile](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.dockerfile)
+
+
+
+License: 
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0, or GNU General Public License, version 2
+with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.

--- a/LICENSE.gitpod.md
+++ b/LICENSE.gitpod.md
@@ -1,14 +1,18 @@
-The Gitpod config files have been copied from the main eclipse-theia repo:
+# License of Gitpod configuration files
 
-[.gitpod.yml](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.yml)
-
-[.gitpod.dockerfile](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.dockerfile)
-
-
-
-License: 
+The Gitpod config files have been copied from the main eclipse-theia repo, which is licensed like so:
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License v. 2.0 which is available at
 https://www.eclipse.org/legal/epl-2.0, or GNU General Public License, version 2
 with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.
+
+Original files:
+
+[.gitpod.yml](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.yml)
+
+[.gitpod.dockerfile](https://github.com/eclipse-theia/theia/blob/c1af83e93712e07049a4cfcf46735b039de24ab8/.gitpod.dockerfile)
+
+Note: The two above copied files are only useful for CI/tests and are not contributing to the Theia extension or example application contained in this repo. The presence of these differently licensed files in the repo would have no impact on the licensing of the Trace extension or the example application, that can both remain licensed under MIT.
+
+(The MIT license permits re-licensing - that right remains available for anyone to exercise)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# Trace Viewer extension for Theia
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/theia-ide/theia-trace-extension)
+
+# Trace Viewer extension for Theia applications
 
 Theia trace viewer extension using the tsp-typescript-client (https://github.com/theia-ide/tsp-typescript-client) and Trace Server Protocol (https://github.com/theia-ide/trace-server-protocol).
 
 Prerequisites for running this extension are the same as those for [running the theia IDE](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
+
+## Consume the trace viewer extension from npm
+
+We plan to distribute this extension on npm. 
+
+Availability: TBD
 
 ## Build the extension
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Trace Viewer extension for Theia
+
 Theia trace viewer extension using the tsp-typescript-client (https://github.com/theia-ide/tsp-typescript-client) and Trace Server Protocol (https://github.com/theia-ide/trace-server-protocol).
 
 Prerequisites for running this extension are the same as those for [running the theia IDE](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 
 ## Build the extension
+
 Here is the step in order to build the trace viewer
+
 1. Clone this theia-trace-extension repository
 2. `cd theia-trace-extension`
 3. Now you are ready to build the application: `yarn`
@@ -12,12 +15,23 @@ Here is the step in order to build the trace viewer
 **Note for some debian-based machines**: On some distros, there are 2 yarn commands. If you get an error message saying **ERROR: There are no scenarios; must have at least one.**, you are using the wrong yarn. See [https://github.com/yarnpkg/yarn/issues/2821](https://github.com/yarnpkg/yarn/issues/2821).
 
 ## Trying the trace extension
+
 This repo contains an example theia-trace application that includes the trace extension. It has two versions:
+
 - _browser_: a "cloud" application, accessed with a web browser
 - _electron_: a native desktop application
 
 In order to open traces you need a trace server running on the same machine as the trace extension. You can download the [Eclipse Trace Compass server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) or build it yourself using Trace Compass and the Incubator, take a look at the [instruction here](https://www.eclipse.org/tracecompass/download.html).
+
 1. Start the trace server: `./tracecompass-server`
 2. From the repo root:  `yarn start:browser` or `yarn start:electron`
 3. Go to http://localhost:3000 or use the Electron application
 
+## Packaging the Example Theia Trace Viewer Application
+
+It's possible to package the repo's example application with `electron-builder`. After running `yarn` in the repo root, do:
+
+  $> cd electron-app
+  $> yarn package
+
+  The configured Linux packaging(s) will be generated folder `electron-app/dist`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We plan to distribute this extension on npm.
 
 Availability: TBD
 
-## Build the extension
+## Build the extension and example application
 
 Here is the step in order to build the trace viewer
 
@@ -22,11 +22,11 @@ Here is the step in order to build the trace viewer
 
 **Note for some debian-based machines**: On some distros, there are 2 yarn commands. If you get an error message saying **ERROR: There are no scenarios; must have at least one.**, you are using the wrong yarn. See [https://github.com/yarnpkg/yarn/issues/2821](https://github.com/yarnpkg/yarn/issues/2821).
 
-## Trying the trace extension
+## Try the trace extension
 
-This repo contains an example theia-trace application that includes the trace extension. It has two versions:
+This repository contains an example trace-viewer application that includes the trace extension. It has two versions:
 
-- _browser_: a "cloud" application, accessed with a web browser
+- _browser_: a "browser" application, accessed with a web browser
 - _electron_: a native desktop application
 
 In order to open traces you need a trace server running on the same machine as the trace extension. You can download the [Eclipse Trace Compass server](https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/?d) or build it yourself using Trace Compass and the Incubator, take a look at the [instruction here](https://www.eclipse.org/tracecompass/download.html).
@@ -35,7 +35,7 @@ In order to open traces you need a trace server running on the same machine as t
 2. From the repo root:  `yarn start:browser` or `yarn start:electron`
 3. Go to http://localhost:3000 or use the Electron application
 
-## Packaging the Example Theia Trace Viewer Application
+## Package the Example Theia Trace Viewer Application
 
 It's possible to package the repo's example application with `electron-builder`. After running `yarn` in the repo root, do:
 

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -11,11 +11,6 @@
           "editor.autoSave": "on"
         }
       }
-    },
-    "generator": {
-      "config": {
-        "preloadTemplate": "./preload.html"
-      }
     }
   },
   "dependencies": {
@@ -33,6 +28,8 @@
     "@theia/messages": "next",
     "@theia/cpp-debug": "next",
     "@theia/vsx-registry": "next",
+    "@theia/keymaps": "next",
+    "@theia/getting-started": "next",
     "trace-viewer": "0.0.0"
   },
   "devDependencies": {

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -1,7 +1,23 @@
 {
   "private": true,
-  "name": "Browser-Theia-Trace-Example-Application",
-  "version": "0.0.0",
+  "name": "browser-theia-trace-example-app",
+  "version": "0.0.1",
+  "theia": {
+    "target": "browser",
+    "frontend": {
+      "config": {
+        "applicationName": "Theia-Trace Example Application",
+        "preferences": {
+          "editor.autoSave": "on"
+        }
+      }
+    },
+    "generator": {
+      "config": {
+        "preloadTemplate": "./preload.html"
+      }
+    }
+  },
   "dependencies": {
     "@theia/core": "next",
     "@theia/filesystem": "next",
@@ -15,19 +31,89 @@
     "@theia/markers": "next",
     "@theia/monaco": "next",
     "@theia/messages": "next",
-    "@theia/cpp": "next",
     "@theia/cpp-debug": "next",
-    "viewer-prototype": "0.0.0"
+    "@theia/vsx-registry": "next",
+    "trace-viewer": "0.0.0"
   },
   "devDependencies": {
     "@theia/cli": "next"
   },
   "scripts": {
-    "prepare": "theia build --mode development",
-    "start": "theia start",
-    "watch": "theia build --watch --mode development"
+    "prepare": "theia build --mode development && yarn download:plugins",
+    "start": "theia start --plugins=local-dir:./plugins",
+    "watch": "theia build --watch --mode development",
+    "download:plugins": "theia download:plugins -p=true"
   },
-  "theia": {
-    "target": "browser"
+  "engines": {
+    "node": ">=10.2.0 < 12"
+  },
+  "theiaPluginsDir": "plugins",
+  "theiaPlugins": {
+    "vscode-node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
+    "vscode-node-debug2": "https://open-vsx.org/api/ms-vscode/node-debug2/1.33.0/file/ms-vscode.node-debug2-1.33.0.vsix",
+    "vscode-builtin-bat": "https://open-vsx.org/api/vscode/bat/1.39.1/file/vscode.bat-1.39.1.vsix",
+    "vscode-builtin-clojure": "https://open-vsx.org/api/vscode/clojure/1.39.1/file/vscode.clojure-1.39.1.vsix",
+    "vscode-builtin-coffeescript": "https://open-vsx.org/api/vscode/coffeescript/1.39.1/file/vscode.coffeescript-1.39.1.vsix",
+    "vscode-builtin-configuration-editing": "https://open-vsx.org/api/vscode/configuration-editing/1.39.1/file/vscode.configuration-editing-1.39.1.vsix",
+    "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.39.1/file/vscode.cpp-1.39.1.vsix",
+    "vscode-builtin-csharp": "https://open-vsx.org/api/vscode/csharp/1.39.1/file/vscode.csharp-1.39.1.vsix",
+    "vscode-builtin-css": "https://open-vsx.org/api/vscode/css/1.39.1/file/vscode.css-1.39.1.vsix",
+    "vscode-builtin-debug-auto-launch": "https://open-vsx.org/api/vscode/debug-auto-launch/1.39.1/file/vscode.debug-auto-launch-1.39.1.vsix",
+    "vscode-builtin-docker": "https://open-vsx.org/api/vscode/docker/1.39.1/file/vscode.docker-1.39.1.vsix",
+    "vscode-builtin-emmet": "https://open-vsx.org/api/vscode/emmet/1.39.1/file/vscode.emmet-1.39.1.vsix",
+    "vscode-builtin-fsharp": "https://open-vsx.org/api/vscode/fsharp/1.39.1/file/vscode.fsharp-1.39.1.vsix",
+    "vscode-builtin-git": "https://open-vsx.org/api/vscode/git/1.39.1/file/vscode.git-1.39.1.vsix",
+    "vscode-builtin-git-ui": "https://open-vsx.org/api/vscode/git-ui/1.39.1/file/vscode.git-ui-1.39.1.vsix",
+    "vscode-builtin-go": "https://open-vsx.org/api/vscode/go/1.39.1/file/vscode.go-1.39.1.vsix",
+    "vscode-builtin-groovy": "https://open-vsx.org/api/vscode/groovy/1.39.1/file/vscode.groovy-1.39.1.vsix",
+    "vscode-builtin-grunt": "https://open-vsx.org/api/vscode/grunt/1.39.1/file/vscode.grunt-1.39.1.vsix",
+    "vscode-builtin-gulp": "https://open-vsx.org/api/vscode/gulp/1.39.1/file/vscode.gulp-1.39.1.vsix",
+    "vscode-builtin-handlebars": "https://open-vsx.org/api/vscode/handlebars/1.39.1/file/vscode.handlebars-1.39.1.vsix",
+    "vscode-builtin-hlsl": "https://open-vsx.org/api/vscode/hlsl/1.39.1/file/vscode.hlsl-1.39.1.vsix",
+    "vscode-builtin-html": "https://open-vsx.org/api/vscode/html/1.39.1/file/vscode.html-1.39.1.vsix",
+    "vscode-builtin-html-language-features": "https://open-vsx.org/api/vscode/html-language-features/1.39.1/file/vscode.html-language-features-1.39.1.vsix",
+    "vscode-builtin-ini": "https://open-vsx.org/api/vscode/ini/1.39.1/file/vscode.ini-1.39.1.vsix",
+    "vscode-builtin-jake": "https://open-vsx.org/api/vscode/jake/1.39.1/file/vscode.jake-1.39.1.vsix",
+    "vscode-builtin-java": "https://open-vsx.org/api/vscode/java/1.39.1/file/vscode.java-1.39.1.vsix",
+    "vscode-builtin-javascript": "https://open-vsx.org/api/vscode/javascript/1.39.1/file/vscode.javascript-1.39.1.vsix",
+    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.39.1/file/vscode.json-1.39.1.vsix",
+    "vscode-builtin-less": "https://open-vsx.org/api/vscode/less/1.39.1/file/vscode.less-1.39.1.vsix",
+    "vscode-builtin-log": "https://open-vsx.org/api/vscode/log/1.39.1/file/vscode.log-1.39.1.vsix",
+    "vscode-builtin-lua": "https://open-vsx.org/api/vscode/lua/1.39.1/file/vscode.lua-1.39.1.vsix",
+    "vscode-builtin-make": "https://open-vsx.org/api/vscode/make/1.39.1/file/vscode.make-1.39.1.vsix",
+    "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.39.1/file/vscode.markdown-1.39.1.vsix",
+    "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.1/file/vscode.markdown-language-features-1.39.1.vsix",
+    "vscode-builtin-merge-conflict": "https://open-vsx.org/api/vscode/merge-conflict/1.39.1/file/vscode.merge-conflict-1.39.1.vsix",
+    "vscode-builtin-objective-c": "https://open-vsx.org/api/vscode/objective-c/1.39.1/file/vscode.objective-c-1.39.1.vsix",
+    "vscode-builtin-perl": "https://open-vsx.org/api/vscode/perl/1.39.1/file/vscode.perl-1.39.1.vsix",
+    "vscode-builtin-powershell": "https://open-vsx.org/api/vscode/powershell/1.39.1/file/vscode.powershell-1.39.1.vsix",
+    "vscode-builtin-pug": "https://open-vsx.org/api/vscode/pug/1.39.1/file/vscode.pug-1.39.1.vsix",
+    "vscode-builtin-python": "https://open-vsx.org/api/vscode/python/1.39.1/file/vscode.python-1.39.1.vsix",
+    "vscode-builtin-r": "https://open-vsx.org/api/vscode/r/1.39.1/file/vscode.r-1.39.1.vsix",
+    "vscode-builtin-razor": "https://open-vsx.org/api/vscode/razor/1.39.1/file/vscode.razor-1.39.1.vsix",
+    "vscode-builtin-ruby": "https://open-vsx.org/api/vscode/ruby/1.39.1/file/vscode.ruby-1.39.1.vsix",
+    "vscode-builtin-rust": "https://open-vsx.org/api/vscode/rust/1.39.1/file/vscode.rust-1.39.1.vsix",
+    "vscode-builtin-scss": "https://open-vsx.org/api/vscode/scss/1.39.1/file/vscode.scss-1.39.1.vsix",
+    "vscode-builtin-shaderlab": "https://open-vsx.org/api/vscode/shaderlab/1.39.1/file/vscode.shaderlab-1.39.1.vsix",
+    "vscode-builtin-shellscript": "https://open-vsx.org/api/vscode/shellscript/1.39.1/file/vscode.shellscript-1.39.1.vsix",
+    "vscode-builtin-sql": "https://open-vsx.org/api/vscode/sql/1.39.1/file/vscode.sql-1.39.1.vsix",
+    "vscode-builtin-swift": "https://open-vsx.org/api/vscode/swift/1.39.1/file/vscode.swift-1.39.1.vsix",
+    "vscode-builtin-theme-abyss": "https://open-vsx.org/api/vscode/theme-abyss/1.39.1/file/vscode.theme-abyss-1.39.1.vsix",
+    "vscode-builtin-theme-defaults": "https://open-vsx.org/api/vscode/theme-defaults/1.39.1/file/vscode.theme-defaults-1.39.1.vsix",
+    "vscode-builtin-theme-kimbie-dark": "https://open-vsx.org/api/vscode/theme-kimbie-dark/1.39.1/file/vscode.theme-kimbie-dark-1.39.1.vsix",
+    "vscode-builtin-theme-monokai": "https://open-vsx.org/api/vscode/theme-monokai/1.39.1/file/vscode.theme-monokai-1.39.1.vsix",
+    "vscode-builtin-theme-monokai-dimmed": "https://open-vsx.org/api/vscode/theme-monokai-dimmed/1.39.1/file/vscode.theme-monokai-dimmed-1.39.1.vsix",
+    "vscode-builtin-theme-quietlight": "https://open-vsx.org/api/vscode/theme-quietlight/1.39.1/file/vscode.theme-quietlight-1.39.1.vsix",
+    "vscode-builtin-theme-red": "https://open-vsx.org/api/vscode/theme-red/1.39.1/file/vscode.theme-red-1.39.1.vsix",
+    "vscode-builtin-theme-solarized-dark": "https://open-vsx.org/api/vscode/theme-solarized-dark/1.39.1/file/vscode.theme-solarized-dark-1.39.1.vsix",
+    "vscode-builtin-theme-tomorrow-night-blue": "https://open-vsx.org/api/vscode/theme-tomorrow-night-blue/1.39.1/file/vscode.theme-tomorrow-night-blue-1.39.1.vsix",
+    "vscode-builtin-typescript": "https://open-vsx.org/api/vscode/typescript/1.39.1/file/vscode.typescript-1.39.1.vsix",
+    "vscode-builtin-typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.39.1/file/vscode.typescript-language-features-1.39.1.vsix",
+    "vscode-builtin-vb": "https://open-vsx.org/api/vscode/vb/1.39.1/file/vscode.vb-1.39.1.vsix",
+    "vscode-builtin-icon-theme-seti": "https://open-vsx.org/api/vscode/vscode-theme-seti/1.39.1/file/vscode.vscode-theme-seti-1.39.1.vsix",
+    "vscode-builtin-xml": "https://open-vsx.org/api/vscode/xml/1.39.1/file/vscode.xml-1.39.1.vsix",
+    "vscode-builtin-yaml": "https://open-vsx.org/api/vscode/yaml/1.39.1/file/vscode.yaml-1.39.1.vsix",
+    "vscode-editorconfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
+    "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.0.21/file/llvm-vs-code-extensions.vscode-clangd-0.0.21.vsix"
   }
 }

--- a/electron-app/electron-builder.yml
+++ b/electron-app/electron-builder.yml
@@ -1,5 +1,5 @@
 electronDist: node_modules/electron/dist
-productName: Theia Trace Example Aopplication
+productName: Theia Trace Example Application
 appId: theia-trace-example
 
 asar: false

--- a/electron-app/electron-builder.yml
+++ b/electron-app/electron-builder.yml
@@ -1,0 +1,26 @@
+electronDist: node_modules/electron/dist
+productName: Theia Trace Example Aopplication
+appId: theia-trace-example
+
+asar: false
+directories:
+  buildResources: resources
+files:
+  - node_modules
+  - src-gen
+  - lib
+  - scripts
+  - package.json
+extraResources:
+  - from: plugins
+    to: app/plugins
+
+linux:
+  target:
+    - deb
+    - AppImage
+  category: Development
+  icon: resources/icons
+
+appImage:
+  artifactName: ${productName}-${version}.${ext}

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -36,6 +36,8 @@
     "@theia/monaco": "next",
     "@theia/messages": "next",
     "@theia/vsx-registry": "next",
+    "@theia/keymaps": "next",
+    "@theia/getting-started": "next",
     "@theia/electron": "next",
     "trace-viewer": "0.0.0"
   },

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,8 +1,27 @@
 {
   "private": true,
-  "name": "Electron-Theia-Trace-Example-Application",
-  "main": "src-gen/frontend/electron-main.js",
-  "version": "0.0.0",
+  "name": "electron-theia-trace-example-app",
+  "main": "scripts/theia-trace-main.js",
+  "build": {
+    "electronVersion": "4.2.12"
+  },
+  "version": "0.0.1",
+  "theia": {
+    "target": "electron",
+    "backend": {
+      "config": {
+        "startupTimeout": -1
+      }
+    },
+    "frontend": {
+      "config": {
+        "applicationName": "Theia-Trace Example Application",
+        "preferences": {
+          "editor.autoSave": "on"
+        }
+      }
+    }
+  },
   "dependencies": {
     "@theia/core": "next",
     "@theia/filesystem": "next",
@@ -16,20 +35,97 @@
     "@theia/markers": "next",
     "@theia/monaco": "next",
     "@theia/messages": "next",
-    "@theia/cpp": "next",
-    "@theia/cpp-debug": "next",
+    "@theia/vsx-registry": "next",
     "@theia/electron": "next",
-    "viewer-prototype": "0.0.0"
+    "trace-viewer": "0.0.0"
   },
   "devDependencies": {
-    "@theia/cli": "next"
+    "@theia/cli": "next",
+    "electron-builder": "^22.3.2"
   },
   "scripts": {
-    "prepare": "theia build --mode development",
-    "start": "theia start",
-    "watch": "theia build --watch --mode development"
+    "prepare": "theia build --mode development && yarn download:plugins",
+    "start": "theia start --plugins=local-dir:./plugins",
+    "watch": "theia build --watch --mode development",
+    "package": "electron-builder",
+    "package:preview": "electron-builder --dir",
+    "download:plugins": "theia download:plugins -p=true"
   },
-  "theia": {
-    "target": "electron"
+  "engines": {
+    "node": ">=10.2.0 < 12"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia-trace-extension"
+  },
+  "theiaPluginsDir": "plugins",
+  "theiaPlugins": {
+    "vscode-node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
+    "vscode-node-debug2": "https://open-vsx.org/api/ms-vscode/node-debug2/1.33.0/file/ms-vscode.node-debug2-1.33.0.vsix",
+    "vscode-builtin-bat": "https://open-vsx.org/api/vscode/bat/1.39.1/file/vscode.bat-1.39.1.vsix",
+    "vscode-builtin-clojure": "https://open-vsx.org/api/vscode/clojure/1.39.1/file/vscode.clojure-1.39.1.vsix",
+    "vscode-builtin-coffeescript": "https://open-vsx.org/api/vscode/coffeescript/1.39.1/file/vscode.coffeescript-1.39.1.vsix",
+    "vscode-builtin-configuration-editing": "https://open-vsx.org/api/vscode/configuration-editing/1.39.1/file/vscode.configuration-editing-1.39.1.vsix",
+    "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.39.1/file/vscode.cpp-1.39.1.vsix",
+    "vscode-builtin-csharp": "https://open-vsx.org/api/vscode/csharp/1.39.1/file/vscode.csharp-1.39.1.vsix",
+    "vscode-builtin-css": "https://open-vsx.org/api/vscode/css/1.39.1/file/vscode.css-1.39.1.vsix",
+    "vscode-builtin-debug-auto-launch": "https://open-vsx.org/api/vscode/debug-auto-launch/1.39.1/file/vscode.debug-auto-launch-1.39.1.vsix",
+    "vscode-builtin-docker": "https://open-vsx.org/api/vscode/docker/1.39.1/file/vscode.docker-1.39.1.vsix",
+    "vscode-builtin-emmet": "https://open-vsx.org/api/vscode/emmet/1.39.1/file/vscode.emmet-1.39.1.vsix",
+    "vscode-builtin-fsharp": "https://open-vsx.org/api/vscode/fsharp/1.39.1/file/vscode.fsharp-1.39.1.vsix",
+    "vscode-builtin-git": "https://open-vsx.org/api/vscode/git/1.39.1/file/vscode.git-1.39.1.vsix",
+    "vscode-builtin-git-ui": "https://open-vsx.org/api/vscode/git-ui/1.39.1/file/vscode.git-ui-1.39.1.vsix",
+    "vscode-builtin-go": "https://open-vsx.org/api/vscode/go/1.39.1/file/vscode.go-1.39.1.vsix",
+    "vscode-builtin-groovy": "https://open-vsx.org/api/vscode/groovy/1.39.1/file/vscode.groovy-1.39.1.vsix",
+    "vscode-builtin-grunt": "https://open-vsx.org/api/vscode/grunt/1.39.1/file/vscode.grunt-1.39.1.vsix",
+    "vscode-builtin-gulp": "https://open-vsx.org/api/vscode/gulp/1.39.1/file/vscode.gulp-1.39.1.vsix",
+    "vscode-builtin-handlebars": "https://open-vsx.org/api/vscode/handlebars/1.39.1/file/vscode.handlebars-1.39.1.vsix",
+    "vscode-builtin-hlsl": "https://open-vsx.org/api/vscode/hlsl/1.39.1/file/vscode.hlsl-1.39.1.vsix",
+    "vscode-builtin-html": "https://open-vsx.org/api/vscode/html/1.39.1/file/vscode.html-1.39.1.vsix",
+    "vscode-builtin-html-language-features": "https://open-vsx.org/api/vscode/html-language-features/1.39.1/file/vscode.html-language-features-1.39.1.vsix",
+    "vscode-builtin-ini": "https://open-vsx.org/api/vscode/ini/1.39.1/file/vscode.ini-1.39.1.vsix",
+    "vscode-builtin-jake": "https://open-vsx.org/api/vscode/jake/1.39.1/file/vscode.jake-1.39.1.vsix",
+    "vscode-builtin-java": "https://open-vsx.org/api/vscode/java/1.39.1/file/vscode.java-1.39.1.vsix",
+    "vscode-builtin-javascript": "https://open-vsx.org/api/vscode/javascript/1.39.1/file/vscode.javascript-1.39.1.vsix",
+    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.39.1/file/vscode.json-1.39.1.vsix",
+    "vscode-builtin-less": "https://open-vsx.org/api/vscode/less/1.39.1/file/vscode.less-1.39.1.vsix",
+    "vscode-builtin-log": "https://open-vsx.org/api/vscode/log/1.39.1/file/vscode.log-1.39.1.vsix",
+    "vscode-builtin-lua": "https://open-vsx.org/api/vscode/lua/1.39.1/file/vscode.lua-1.39.1.vsix",
+    "vscode-builtin-make": "https://open-vsx.org/api/vscode/make/1.39.1/file/vscode.make-1.39.1.vsix",
+    "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.39.1/file/vscode.markdown-1.39.1.vsix",
+    "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.1/file/vscode.markdown-language-features-1.39.1.vsix",
+    "vscode-builtin-merge-conflict": "https://open-vsx.org/api/vscode/merge-conflict/1.39.1/file/vscode.merge-conflict-1.39.1.vsix",
+    "vscode-builtin-objective-c": "https://open-vsx.org/api/vscode/objective-c/1.39.1/file/vscode.objective-c-1.39.1.vsix",
+    "vscode-builtin-perl": "https://open-vsx.org/api/vscode/perl/1.39.1/file/vscode.perl-1.39.1.vsix",
+    "vscode-builtin-powershell": "https://open-vsx.org/api/vscode/powershell/1.39.1/file/vscode.powershell-1.39.1.vsix",
+    "vscode-builtin-pug": "https://open-vsx.org/api/vscode/pug/1.39.1/file/vscode.pug-1.39.1.vsix",
+    "vscode-builtin-python": "https://open-vsx.org/api/vscode/python/1.39.1/file/vscode.python-1.39.1.vsix",
+    "vscode-builtin-r": "https://open-vsx.org/api/vscode/r/1.39.1/file/vscode.r-1.39.1.vsix",
+    "vscode-builtin-razor": "https://open-vsx.org/api/vscode/razor/1.39.1/file/vscode.razor-1.39.1.vsix",
+    "vscode-builtin-ruby": "https://open-vsx.org/api/vscode/ruby/1.39.1/file/vscode.ruby-1.39.1.vsix",
+    "vscode-builtin-rust": "https://open-vsx.org/api/vscode/rust/1.39.1/file/vscode.rust-1.39.1.vsix",
+    "vscode-builtin-scss": "https://open-vsx.org/api/vscode/scss/1.39.1/file/vscode.scss-1.39.1.vsix",
+    "vscode-builtin-shaderlab": "https://open-vsx.org/api/vscode/shaderlab/1.39.1/file/vscode.shaderlab-1.39.1.vsix",
+    "vscode-builtin-shellscript": "https://open-vsx.org/api/vscode/shellscript/1.39.1/file/vscode.shellscript-1.39.1.vsix",
+    "vscode-builtin-sql": "https://open-vsx.org/api/vscode/sql/1.39.1/file/vscode.sql-1.39.1.vsix",
+    "vscode-builtin-swift": "https://open-vsx.org/api/vscode/swift/1.39.1/file/vscode.swift-1.39.1.vsix",
+    "vscode-builtin-theme-abyss": "https://open-vsx.org/api/vscode/theme-abyss/1.39.1/file/vscode.theme-abyss-1.39.1.vsix",
+    "vscode-builtin-theme-defaults": "https://open-vsx.org/api/vscode/theme-defaults/1.39.1/file/vscode.theme-defaults-1.39.1.vsix",
+    "vscode-builtin-theme-kimbie-dark": "https://open-vsx.org/api/vscode/theme-kimbie-dark/1.39.1/file/vscode.theme-kimbie-dark-1.39.1.vsix",
+    "vscode-builtin-theme-monokai": "https://open-vsx.org/api/vscode/theme-monokai/1.39.1/file/vscode.theme-monokai-1.39.1.vsix",
+    "vscode-builtin-theme-monokai-dimmed": "https://open-vsx.org/api/vscode/theme-monokai-dimmed/1.39.1/file/vscode.theme-monokai-dimmed-1.39.1.vsix",
+    "vscode-builtin-theme-quietlight": "https://open-vsx.org/api/vscode/theme-quietlight/1.39.1/file/vscode.theme-quietlight-1.39.1.vsix",
+    "vscode-builtin-theme-red": "https://open-vsx.org/api/vscode/theme-red/1.39.1/file/vscode.theme-red-1.39.1.vsix",
+    "vscode-builtin-theme-solarized-dark": "https://open-vsx.org/api/vscode/theme-solarized-dark/1.39.1/file/vscode.theme-solarized-dark-1.39.1.vsix",
+    "vscode-builtin-theme-tomorrow-night-blue": "https://open-vsx.org/api/vscode/theme-tomorrow-night-blue/1.39.1/file/vscode.theme-tomorrow-night-blue-1.39.1.vsix",
+    "vscode-builtin-typescript": "https://open-vsx.org/api/vscode/typescript/1.39.1/file/vscode.typescript-1.39.1.vsix",
+    "vscode-builtin-typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.39.1/file/vscode.typescript-language-features-1.39.1.vsix",
+    "vscode-builtin-vb": "https://open-vsx.org/api/vscode/vb/1.39.1/file/vscode.vb-1.39.1.vsix",
+    "vscode-builtin-icon-theme-seti": "https://open-vsx.org/api/vscode/vscode-theme-seti/1.39.1/file/vscode.vscode-theme-seti-1.39.1.vsix",
+    "vscode-builtin-xml": "https://open-vsx.org/api/vscode/xml/1.39.1/file/vscode.xml-1.39.1.vsix",
+    "vscode-builtin-yaml": "https://open-vsx.org/api/vscode/yaml/1.39.1/file/vscode.yaml-1.39.1.vsix",
+    "vscode-editorconfig": "https://open-vsx.org/api/EditorConfig/EditorConfig/0.14.4/file/EditorConfig.EditorConfig-0.14.4.vsix",
+    "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.0.21/file/llvm-vs-code-extensions.vscode-clangd-0.0.21.vsix",
+    "cdt-gdb-vscode": "https://open-vsx.org/api/eclipse-cdt/cdt-gdb-vscode/0.0.91/file/eclipse-cdt.cdt-gdb-vscode-0.0.91.vsix"
   }
 }

--- a/electron-app/resources/todo.txt
+++ b/electron-app/resources/todo.txt
@@ -1,0 +1,2 @@
+add icon here
+`

--- a/electron-app/scripts/theia-trace-main.js
+++ b/electron-app/scripts/theia-trace-main.js
@@ -1,0 +1,4 @@
+const { resolve } = require('path');
+
+process.env.THEIA_DEFAULT_PLUGINS = `local-dir:${resolve(__dirname, '..', 'plugins')}`;
+require('../src-gen/frontend/electron-main');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
     "rebuild:browser": "theia rebuild:browser",
     "rebuild:electron": "theia rebuild:electron",
     "start:browser": "yarn rebuild:browser ; yarn --cwd browser-app start",
-    "start:electron": "yarn rebuild:electron ; yarn --cwd electron-app start"
+    "start:electron": "yarn rebuild:electron ; yarn --cwd electron-app start",
+    "download:sample-traces": "git clone https://github.com/tracecompass/tracecompass-test-traces.git; ln -s tracecompass-test-traces/ctf/src/main/resources sample-traces",
+    "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz",
+    "start:server": "./trace-compass-server/tracecompass-server",
+    "start-all:browser": "yarn start:server & yarn start:browser",
+    "start-all:electron": "yarn start:server & yarn start:electron"
   },
   "devDependencies": {
     "lerna": "2.4.0"

--- a/viewer-prototype/package.json
+++ b/viewer-prototype/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "viewer-prototype",
+  "name": "trace-viewer",
+  "private": "true",
   "version": "0.0.0",
-  "description": "Theia - Trace Compass trace viewer",
+  "description": "Trace Compass trace viewer Theia Extension",
   "keywords": [
     "theia-extension"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,16 +999,16 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@theia/application-manager@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.3.0-next.309b2189.tgz#dfa661e9c7df3deca6fae1cff6d081aefcb79a14"
-  integrity sha512-hnfGfVU45hGFANVPYtm4DvF4m0CF5OGVzYHdGS9TMu0DIOMFQDJYlmzJ0z6H/+06zQ1B1YLa7hBBIY9UnjvRSg==
+"@theia/application-manager@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.3.0-next.310ff528.tgz#cd037e55ca84ee66d66088e6f9761a1c56f0ac8a"
+  integrity sha512-VOIiSF6mD3cAoIwny7v4IOkg7KshQl1XUeH4+o6I0zYhSDTwBev5a3PDeV1NNEXmZa30hfncrDrxAlOg8F6Xvw==
   dependencies:
     "@babel/core" "^7.5.5"
     "@babel/plugin-transform-classes" "^7.5.5"
     "@babel/plugin-transform-runtime" "^7.5.5"
     "@babel/preset-env" "^7.5.5"
-    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/application-package" "1.3.0-next.310ff528"
     "@theia/compression-webpack-plugin" "^3.0.0"
     "@types/fs-extra" "^4.0.2"
     "@types/webpack" "^4.41.2"
@@ -1031,10 +1031,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.3.0-next.309b2189.tgz#e3e0bb2b7e5e44460daa4a1ba8b30510b793f9b5"
-  integrity sha512-HBuCfVYV7siSDJ5i7d4QUZDwuBpJ4inyCBfLRlNuSH3Vo+7L9DCL6Ul7bHjORo58yOUdoOYV1eXGdDYvi+r8EQ==
+"@theia/application-package@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.3.0-next.310ff528.tgz#b45ad38eaf2134f26aaa836d05086669931d554b"
+  integrity sha512-9ru1Fynt6SYEw3VCwsYlZCJdoDs+/C1DlF8Ks0pYLewGC4RYgPxNCBREPmk2Rf4pwwtEVof+TEj+lFMD5CgTRQ==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -1047,24 +1047,24 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/callhierarchy@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-1.3.0-next.309b2189.tgz#f761fb2abc04d2204bafed5ca496f615dad65cde"
-  integrity sha512-1u7UE7LImHS8IU5i3xaLCU+7qxCzHLVxJHibMLjGCcNZS3CaPZkgINBZdJ7ypT3qr2Nwn/5tM1BYtCuSnJYtVA==
+"@theia/callhierarchy@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-1.3.0-next.310ff528.tgz#e761ad61c89ed56a1a325595a5b243d7ee4ec9aa"
+  integrity sha512-hSV2PUndIu8L3zyo63GzVSz1IXY0WXs4jWOKFiMXCBtJOago3WvdMg4W2Jv2HNxo9Z7OUcge56L3LSl2A4u/0w==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/languages" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/languages" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
     ts-md5 "^1.2.2"
 
 "@theia/cli@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.3.0-next.309b2189.tgz#f97b6152bfb89c5120cedaf93d852f895cb675e7"
-  integrity sha512-QJGCBwtY+ANaKbaisZLoUi63BDU6r4L1MbRAFMaGpmGDoUpUsHXyRmKyf2jEzyE4loE6ziG+7d/W94/YBBw64w==
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.3.0-next.310ff528.tgz#feb137acac754904a316bac12cb469dc2763985f"
+  integrity sha512-cJboKwmyb8uuFpIAHwQnWAf78TJvVyJkzMUVb6i+oB6LQLTw0qNcCNgS7HSzgIYykC1Aucld/12zlLGjROoWZg==
   dependencies:
-    "@theia/application-manager" "1.3.0-next.309b2189"
-    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/application-manager" "1.3.0-next.310ff528"
+    "@theia/application-package" "1.3.0-next.310ff528"
     "@types/chai" "^4.2.7"
     "@types/mkdirp" "^0.5.2"
     "@types/mocha" "^5.2.7"
@@ -1097,32 +1097,32 @@
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
 
-"@theia/console@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.3.0-next.309b2189.tgz#d207a4a95927445e531f926e4196c1b5df34930e"
-  integrity sha512-SGP2aWENy74hSubmb/75ausKSlCUbreD6hfWKjK3xOJ+H60Uj6fGEAIgDy6yTFFNp68qAa8CWt3o/9Yqhfum3Q==
+"@theia/console@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.3.0-next.310ff528.tgz#5b32fa881f5aeffd5b038c1bb591a6b7e645cc82"
+  integrity sha512-oaOrv8n6TYOOmrnEnlJSS0UXrDx2wlqOUIa7qis3UhqYhYXWnMStaoh1/FcAUnvilxbp4jb5nQ2Beid/ws0Hcw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
     anser "^1.4.7"
 
-"@theia/core@1.3.0-next.309b2189", "@theia/core@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.3.0-next.309b2189.tgz#3a64817306d87fdb3d67e0d42477c241f7a565eb"
-  integrity sha512-JrmTamN4tEJsILmHRGakZBPHveBqgbybg7BG8cilXi/0amYfw5qKn8oALUKlpTfJ4F9bew5REb1hCxpW4GO6mg==
+"@theia/core@1.3.0-next.310ff528", "@theia/core@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.3.0-next.310ff528.tgz#5a982e845a2eb3d7934df8c4c299f6e85f52b158"
+  integrity sha512-Cl1R/vYFvu/vMCiHb/lgpzaG/w+CyIxrze2eulNNCwj85ILNxcHIgXaci/pbCwL9pSoZTyajONMhsQMdDcWxbA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@phosphor/widgets" "^1.9.3"
     "@primer/octicons-react" "^9.0.0"
-    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/application-package" "1.3.0-next.310ff528"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/express" "^4.16.0"
     "@types/fs-extra" "^4.0.2"
     "@types/lodash.debounce" "4.0.3"
     "@types/lodash.throttle" "^4.1.3"
-    "@types/react" "^16.4.1"
-    "@types/react-dom" "^16.0.6"
+    "@types/react" "^16.8.0"
+    "@types/react-dom" "^16.8.0"
     "@types/react-virtualized" "^9.18.3"
     "@types/route-parser" "^0.1.1"
     "@types/ws" "^5.1.2"
@@ -1142,8 +1142,8 @@
     nsfw "^1.2.9"
     p-debounce "^2.1.0"
     perfect-scrollbar "^1.3.0"
-    react "^16.4.1"
-    react-dom "^16.4.1"
+    react "^16.8.0"
+    react-dom "^16.8.0"
     react-virtualized "^9.20.0"
     reconnecting-websocket "^4.2.0"
     reflect-metadata "^0.1.10"
@@ -1164,27 +1164,27 @@
     ajv "^6.5.3"
     lodash "^4.17.10"
 
-"@theia/debug@1.3.0-next.309b2189", "@theia/debug@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.3.0-next.309b2189.tgz#f113d7d365ccc450ebe67a092a9a827a2385f44a"
-  integrity sha512-rSgl2NSzorMJ4r7q+GafFlmpzzK+R3p1jdKKXbB8I81JSnm4hNTHDgLoUXEgVKwUJQRaOCj9H6C9YfJzdt/1WA==
+"@theia/debug@1.3.0-next.310ff528", "@theia/debug@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.3.0-next.310ff528.tgz#8df6a9f721cef9fe23a45465680b981a0638102d"
+  integrity sha512-gjjbYrSBDnyyL+W8O6zu7zfdAecXLhPg29rk3FtqDvhMvsI07ddkYtA4m0OC11WtYnGRPTJVWa3EQ5/lukFmNg==
   dependencies:
-    "@theia/application-package" "1.3.0-next.309b2189"
-    "@theia/console" "1.3.0-next.309b2189"
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/languages" "1.3.0-next.309b2189"
-    "@theia/markers" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
-    "@theia/output" "1.3.0-next.309b2189"
-    "@theia/preferences" "1.3.0-next.309b2189"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/task" "1.3.0-next.309b2189"
-    "@theia/terminal" "1.3.0-next.309b2189"
-    "@theia/userstorage" "1.3.0-next.309b2189"
-    "@theia/variable-resolver" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/application-package" "1.3.0-next.310ff528"
+    "@theia/console" "1.3.0-next.310ff528"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/languages" "1.3.0-next.310ff528"
+    "@theia/markers" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/output" "1.3.0-next.310ff528"
+    "@theia/preferences" "1.3.0-next.310ff528"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/task" "1.3.0-next.310ff528"
+    "@theia/terminal" "1.3.0-next.310ff528"
+    "@theia/userstorage" "1.3.0-next.310ff528"
+    "@theia/variable-resolver" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     jsonc-parser "^2.0.2"
     mkdirp "^0.5.0"
     p-debounce "^2.1.0"
@@ -1193,21 +1193,21 @@
     unzip-stream "^0.3.0"
     vscode-debugprotocol "^1.32.0"
 
-"@theia/editor@1.3.0-next.309b2189", "@theia/editor@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.3.0-next.309b2189.tgz#e8ed81890cd6b68f83028a1f540a6ade608a9519"
-  integrity sha512-WkOkzk0a8po8z2p4Vi8O84HrVa1eDmVx4eotSpdqrZQqUR6xpf/UrrSrdB4IyC2jmN3NuxhenAXkROM08BkkcQ==
+"@theia/editor@1.3.0-next.310ff528", "@theia/editor@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.3.0-next.310ff528.tgz#ddfc4d3305c20c6c37486d4a787cf9e1e7f6b1a1"
+  integrity sha512-a25GqOEObR+Upv1C9+SfTBSFnTevP+VWihvjyGbCGYkE842APG7ZdE+J32EQFBqPG6X5jmzB+smqqy28bH/2zA==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/languages" "1.3.0-next.309b2189"
-    "@theia/variable-resolver" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/languages" "1.3.0-next.310ff528"
+    "@theia/variable-resolver" "1.3.0-next.310ff528"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
 "@theia/electron@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/electron/-/electron-1.3.0-next.309b2189.tgz#306e83f2c080bde730920641aa0849f629489382"
-  integrity sha512-so1Bp0HkTCZ0uevdib436u+9iwPo7cJDo+RS8KArZD6efTTLnPxUrYB8ikKYUq4WFoUJogk5v+/r4vzC/PhTHg==
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/electron/-/electron-1.3.0-next.310ff528.tgz#38957bdeffb41589fa6fe42f7ed9e920f81e2fbf"
+  integrity sha512-zuji7Mg8WaOii0Tuiu41CmK2Am5LhxKwCCJsZ2/0ydaJLCeDU0uwLsTBkDAs46fOXfUC2SzIetC5i1UGsNlfjw==
   dependencies:
     electron "^4.2.11"
     electron-download "^4.1.1"
@@ -1218,26 +1218,26 @@
     unzipper "^0.9.11"
     yargs "^11.1.0"
 
-"@theia/file-search@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-1.3.0-next.309b2189.tgz#925d73ad59347bb8e2f96454710b2f96266206f3"
-  integrity sha512-4O2Xl6CfV+Xg9Jp2a/Ti+QZutT3awI809AVyewrjm2RxXDl8q9uQteXwDz4xrFGj6twywcumMgKnaDyhLR6NBw==
+"@theia/file-search@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-1.3.0-next.310ff528.tgz#164b4f7faa9fbc51731a22e03264e8f843e931b0"
+  integrity sha512-ZsKmeEPwRK3txceQrCHEH437audNpNFVMiel5HO34PVs2kaGA3/TmocZbfMRQnCg6eMG4yG38kKyUFtWgj9Skg==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     fuzzy "^0.1.3"
     vscode-ripgrep "^1.2.4"
 
-"@theia/filesystem@1.3.0-next.309b2189", "@theia/filesystem@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.3.0-next.309b2189.tgz#a9d76337485135cbdb6bd3b0ea1057b394835c98"
-  integrity sha512-+L3yg6XpClT5oRqv3mi9/F5thhkqnjZxs3i3uH6JEXYtULEsGPAWLl/rbj30D0jkUTaNyxH8V58Tv9CNJy8cxw==
+"@theia/filesystem@1.3.0-next.310ff528", "@theia/filesystem@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.3.0-next.310ff528.tgz#c91221cd5042ed4c376d642b37f9914f018f2649"
+  integrity sha512-LFs2EjKLUHFQFK6qvH2YjJ9H72eaegn08gqUT7TdheQ7nchg6xje5bplwAiqn+99jmXQi0mdcMKei/wjeQuyZA==
   dependencies:
-    "@theia/application-package" "1.3.0-next.309b2189"
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/application-package" "1.3.0-next.310ff528"
+    "@theia/core" "1.3.0-next.310ff528"
     "@types/body-parser" "^1.17.0"
     "@types/rimraf" "^2.0.2"
     "@types/tar-fs" "^1.16.1"
@@ -1257,36 +1257,61 @@
     uuid "^8.0.0"
     zip-dir "^1.0.2"
 
-"@theia/languages@1.3.0-next.309b2189", "@theia/languages@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-1.3.0-next.309b2189.tgz#5c1b6a30b0eb7d7b753d039a7a0c004d65c71a90"
-  integrity sha512-2m2GrMaNdjJc02jmzetyfXqLLkiAhisDBmqGZnuXWg3IMkUPYeIiJsQNC/2u1t3EmNa4AxYqn0wlwKGEj7Xohw==
+"@theia/getting-started@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/getting-started/-/getting-started-1.3.0-next.310ff528.tgz#cf3c17cc116bc7ddb9f04392c872523c88b61807"
+  integrity sha512-YGVqEZwm+Swof9y4W2KZgx5AvYzyRutniSfvyvaJ4r16qbkJkSQtOFLnJDl7JicyY0wKFWwTQa6l36ybHZj2Mg==
   dependencies:
-    "@theia/application-package" "1.3.0-next.309b2189"
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/keymaps" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
+
+"@theia/keymaps@1.3.0-next.310ff528", "@theia/keymaps@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/keymaps/-/keymaps-1.3.0-next.310ff528.tgz#70a599c59a42ff87ba480a20bca600acdba792d2"
+  integrity sha512-4DfFJ5MbjKWh8vGn4e0ynXoQoSQvSD2ymscH/AvBAabMU7J9kE2TTi9jsasH+pPng1CjaxsXHRT8elkIhFbH0Q==
+  dependencies:
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/userstorage" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
+    "@types/lodash.debounce" "4.0.3"
+    ajv "^6.5.3"
+    fuzzy "^0.1.3"
+    jsonc-parser "^2.0.2"
+    lodash.debounce "^4.0.8"
+
+"@theia/languages@1.3.0-next.310ff528", "@theia/languages@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-1.3.0-next.310ff528.tgz#d0c908a6f5cc232a88ef012f3acd11014d4db0ce"
+  integrity sha512-VQ9bWCAEjvss3f1QO8S/T0ix/mjtN1W/4/4I3+3p8an1Ku8ZSLjKNs/GNquV99VDnguXnY029EXyeSiDMpsKAQ==
+  dependencies:
+    "@theia/application-package" "1.3.0-next.310ff528"
+    "@theia/core" "1.3.0-next.310ff528"
     "@theia/monaco-editor-core" "^0.19.3"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     "@types/uuid" "^7.0.3"
     monaco-languageclient "^0.13.0"
     uuid "^8.0.0"
 
-"@theia/markers@1.3.0-next.309b2189", "@theia/markers@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.3.0-next.309b2189.tgz#fb0a7c5d0604be3c7c15cc4eb283d53d96b0a1e3"
-  integrity sha512-hAKRzxRdJbWNgaCzrciQ8tF/aRmHG3zPW3yVPX+FgqgiOPJYoZZTz28WZLeR/ZdXvRxMGH7Sf4GSq+cH+xAH4A==
+"@theia/markers@1.3.0-next.310ff528", "@theia/markers@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.3.0-next.310ff528.tgz#cc375f1d3443d8fddfd3d83ac5c532760dc310c6"
+  integrity sha512-pLxXPKbc/WTXpAQV7FsVNJT6VFtAPLmDwSQ9T9S9JoO5B6jgFNvaC/6KLVKcgR9EqoTB289M2l7+1aPdZNPn8A==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/navigator" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/navigator" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
 
-"@theia/messages@1.3.0-next.309b2189", "@theia/messages@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.3.0-next.309b2189.tgz#21e56e227c2c50366a44482d52beb865ede00cda"
-  integrity sha512-6CO718bam7cMtBPaUoA6LFBXn/DWD9tIR4RnTSltZAtyNcjmZs6G+9j2lpbHNYEKYdd0FW53jrfRvsm9kJokZw==
+"@theia/messages@1.3.0-next.310ff528", "@theia/messages@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.3.0-next.310ff528.tgz#ddfdc9b184c90f713a4c01aeab0c2626acb23ab9"
+  integrity sha512-H7Rf3WG1mWYaAex5b3ge0Tx+dTIP72gxRyFos8PD0DJ8HsP1cONKTsG5wJZJMqNeS5jveYQS3DIAoxTFNO7ibw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
     lodash.throttle "^4.1.1"
     markdown-it "^8.4.0"
     react-perfect-scrollbar "^1.5.3"
@@ -1297,18 +1322,18 @@
   resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-0.19.3.tgz#8456aaa52f4cdc87c78697a0edfcccb9696a374d"
   integrity sha512-+2I5pvbK9qxWs+bLFUwto8nYubyI759/p0z86r2w0HnFdcMQ6rcqvcTupO/Cd/YAJ1/IU38PBWS7hwIoVnvCsQ==
 
-"@theia/monaco@1.3.0-next.309b2189", "@theia/monaco@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.3.0-next.309b2189.tgz#3fa0785e03953b0300019f7f7aea4c10a6d3f509"
-  integrity sha512-AtbMK4GvPW4w2ZxcOlHidDEk/CPr80koSjR9s3Eqy9dMdLYRBosR+LckrfYDuIjTUkIjZ5Wy/cuqJK2N5By2Sw==
+"@theia/monaco@1.3.0-next.310ff528", "@theia/monaco@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.3.0-next.310ff528.tgz#9a3c6189b987ae28cec0c91fd6a8b9352fa8dc4d"
+  integrity sha512-wFcLZCqakDrQTQc4HcH+OWT6cnZHyyJqWqNvVnWAuESj4JzDfNQyzFCQ6w4/vuV1Grfy94nIv6jEeQJ/QcIPag==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/languages" "1.3.0-next.309b2189"
-    "@theia/markers" "1.3.0-next.309b2189"
-    "@theia/outline-view" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/languages" "1.3.0-next.310ff528"
+    "@theia/markers" "1.3.0-next.310ff528"
+    "@theia/outline-view" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     deepmerge "2.0.1"
     fast-plist "^0.1.2"
     idb "^4.0.5"
@@ -1318,14 +1343,14 @@
     onigasm "^2.2.0"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@1.3.0-next.309b2189", "@theia/navigator@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.3.0-next.309b2189.tgz#a2094ed3219327296411eee6d04163e538fc8259"
-  integrity sha512-hQ/d1uuqMDOtHIgfnb8EkZseA+0/jCwiRzulRiTak7qzhozO+h6cXGpRkglyvvYiZ/2YwClEdsQwWQ9jBCktwQ==
+"@theia/navigator@1.3.0-next.310ff528", "@theia/navigator@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.3.0-next.310ff528.tgz#80d88e1dcf1d3c9b17723a0b94e8591170f1977e"
+  integrity sha512-473Z4S3LbTt2HNgpqSSgN+bL5nS3Yhc//VTfZDjK9s7drZvZti4Fjsae768jHWO/+Vojtslw9E3KUIhCFbgqNw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
@@ -1336,63 +1361,63 @@
   dependencies:
     nan "^2.14.0"
 
-"@theia/outline-view@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.3.0-next.309b2189.tgz#1b6f16a88a9f09966902be6a02c51599cc7a35ff"
-  integrity sha512-qbwMpB4TVUnz8FcEPOTOW2VMBKW+Nk4Jx++yP5Bx25UsOGeV+v5tlD726yDcTE+DFCWoOIghx5DMUEyr56CZEg==
+"@theia/outline-view@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.3.0-next.310ff528.tgz#62286b25d4af960f6f9a9c8418ceeceefc058184"
+  integrity sha512-xhV6eXmCKNPBA30KfGKCP/W1DJOSohH53T73VU/SoLiNX/9om7WrLAY3GeLedbCWpl/Ptdz/xXZOBowEvWubrA==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
 
-"@theia/output@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.3.0-next.309b2189.tgz#cfbafba7cb86ebfbf9d30941cb03715a3bf60afa"
-  integrity sha512-QCqb2SK5Mo8ixCp8/62XlxFdjBqyQ/ahcEBn40ClrYlKnl+NmC5LRMYbF8bBaluIOV019LmeIPBBzwSj/OMygg==
+"@theia/output@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.3.0-next.310ff528.tgz#a61a0952960ca8e4d377a84aae7a3508b6f18388"
+  integrity sha512-5nFCs92PFmNCUkWgckKWepyhyPJQrTHT1LsPAK7QPFo1M5SQSEsFlsFCDw9fq0+1iZCOQRg5yKnJpvhc7U+tHw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
     "@types/p-queue" "^2.3.1"
     p-queue "^2.4.2"
 
-"@theia/plugin-ext-vscode@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/plugin-ext-vscode/-/plugin-ext-vscode-1.3.0-next.309b2189.tgz#faffdc3f5835c4e6f5af78ee459bace0dc4bcf35"
-  integrity sha512-m5rHRi3LBsNraSwX5vEBnh/oz43ytayGTPq5P0Mj7hON+m2dSSeLOF9CM0mxANJcVF8RNrYnMuX8fCDgGzB8NQ==
+"@theia/plugin-ext-vscode@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext-vscode/-/plugin-ext-vscode-1.3.0-next.310ff528.tgz#96bdfcf73cff403c9aafb20fdb09ea91a55861b3"
+  integrity sha512-/RMY2zib7OAVHIu476Uoo5IVF//7pXSweuYCIHDE8pEUfsFPWGQXikDvd9xYJf8lcL5eZNNn4uJMinOomau2qw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
-    "@theia/plugin" "1.3.0-next.309b2189"
-    "@theia/plugin-ext" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/plugin" "1.3.0-next.310ff528"
+    "@theia/plugin-ext" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     "@types/request" "^2.0.3"
     filenamify "^4.1.0"
     request "^2.82.0"
 
-"@theia/plugin-ext@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/plugin-ext/-/plugin-ext-1.3.0-next.309b2189.tgz#6d749fcc733661a022a3caf2f05cb224bfc3f179"
-  integrity sha512-dvIZSwsY6QT97smHHGyzHo+zERndXb2hXOlicPje1AsjoX018OJAPfuzwD7ZpFQwJpZPY/A3x4GH+cQHrw4DtQ==
+"@theia/plugin-ext@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext/-/plugin-ext-1.3.0-next.310ff528.tgz#e4706224cb468fd2e31e8c7a68413672e9c08a43"
+  integrity sha512-2k1Y9Lp+NS36bjiUjOuO6IW9YCRHDwg5Q9u5DfyuKPML+HuZE3MZUk7Xs0Zy8by+wysk8zNE6Sg+4H9ycliIqg==
   dependencies:
-    "@theia/callhierarchy" "1.3.0-next.309b2189"
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/debug" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/file-search" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/languages" "1.3.0-next.309b2189"
-    "@theia/markers" "1.3.0-next.309b2189"
-    "@theia/messages" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
-    "@theia/navigator" "1.3.0-next.309b2189"
-    "@theia/output" "1.3.0-next.309b2189"
-    "@theia/plugin" "1.3.0-next.309b2189"
-    "@theia/preferences" "1.3.0-next.309b2189"
-    "@theia/scm" "1.3.0-next.309b2189"
-    "@theia/search-in-workspace" "1.3.0-next.309b2189"
-    "@theia/task" "1.3.0-next.309b2189"
-    "@theia/terminal" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/callhierarchy" "1.3.0-next.310ff528"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/debug" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/file-search" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/languages" "1.3.0-next.310ff528"
+    "@theia/markers" "1.3.0-next.310ff528"
+    "@theia/messages" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/navigator" "1.3.0-next.310ff528"
+    "@theia/output" "1.3.0-next.310ff528"
+    "@theia/plugin" "1.3.0-next.310ff528"
+    "@theia/preferences" "1.3.0-next.310ff528"
+    "@theia/scm" "1.3.0-next.310ff528"
+    "@theia/search-in-workspace" "1.3.0-next.310ff528"
+    "@theia/task" "1.3.0-next.310ff528"
+    "@theia/terminal" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     "@types/connect" "^3.4.32"
     "@types/mime" "^2.0.1"
     "@types/serve-static" "^1.13.3"
@@ -1412,116 +1437,116 @@
     vscode-debugprotocol "^1.32.0"
     vscode-textmate "^4.0.1"
 
-"@theia/plugin@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/plugin/-/plugin-1.3.0-next.309b2189.tgz#bd7e23b7a7d97b2bf83133d786118feee153bd14"
-  integrity sha512-/E6YjRlW9vnl4C2TqMOlHHnMjJNc33V14fSS/vmF7rcHJRugVDh61c5hBNOI6GvgLedPXqjYgGh9bKRwaVyLKw==
+"@theia/plugin@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/plugin/-/plugin-1.3.0-next.310ff528.tgz#00bfc7fbd5ed1df206f4fc3ea6f5f8aff2e719c2"
+  integrity sha512-Sf3dN9cfV0I/w5tjymOozk2nFS5MfL0neanBYaVLvSKoZV9sWGH858si8V3ar/vwUwyp63+/KpXoaaMNWHNyvg==
 
-"@theia/preferences@1.3.0-next.309b2189", "@theia/preferences@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.3.0-next.309b2189.tgz#b3d4942bd707dcfeb26cd1d11f97d928a64f7f43"
-  integrity sha512-4udY9FybAY+888EduhYQABp2ua5ugaHKqY1BFYnpFoqUdcll6OEEly+VL9KbJ3bTIQkbjIIZzoDZ28wQXAu6bQ==
+"@theia/preferences@1.3.0-next.310ff528", "@theia/preferences@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.3.0-next.310ff528.tgz#2ff6b505aa99095cf92e6e99bae15cbe951b650b"
+  integrity sha512-etlQ/FF6El4Gz07874EPaJDQ4DAGDMyY3zcyOU/nfxMRTSdN332wvJMCGHUHA2YeKU//MnPGlrY8R9ERotGBuA==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
-    "@theia/userstorage" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/userstorage" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     jsonc-parser "^2.0.2"
 
-"@theia/process@1.3.0-next.309b2189", "@theia/process@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.3.0-next.309b2189.tgz#3a8e30ad57b26e9848af636556a91478d98ec74f"
-  integrity sha512-xWQBvwQas/UU0jyslRWxYpccejN3YwYNDDtou5VGUEuPMO4aZwgseIJzpGpw1ZKoiuMUVdwv46eylfmhwPa/Hw==
+"@theia/process@1.3.0-next.310ff528", "@theia/process@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.3.0-next.310ff528.tgz#a59ce3af56a364fe5dbd7bc9172c0a3d1ae128a3"
+  integrity sha512-oGuOh2nKAiCfLi4m3rkYOxaQlR+uPjBEyOdNlm+Fb8RLuSXWWOMfRGqbJiLTNq8QzeeosQLrnOB9ao4F88ViFw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
     "@theia/node-pty" "0.9.0-theia.6"
     string-argv "^0.1.1"
 
-"@theia/scm@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/scm/-/scm-1.3.0-next.309b2189.tgz#878306d0b7a577785c918bb8ad8ec9081f02d819"
-  integrity sha512-4YnVQfhw/x6Gw2S1Q/zKlCAeBVycD+0hSmgiX1R17nEOfSH4Is9RdIhxvGdXnYazWjVmaQQ69Om+lKJvjR3Okw==
+"@theia/scm@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/scm/-/scm-1.3.0-next.310ff528.tgz#ad2a79b40fbc3ff73c76de2a9bb02ff3dbb6dd7e"
+  integrity sha512-YaANPVuzkhacAWlAQW78gXK7aC92OvBbsGMcnCDoX/4M17K265PGZ8eUYisMKuByloo8GAqY8VQNpKTVGeMWjg==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/navigator" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/navigator" "1.3.0-next.310ff528"
     "@types/diff" "^3.2.2"
     diff "^3.4.0"
     p-debounce "^2.1.0"
     react-autosize-textarea "^7.0.0"
     ts-md5 "^1.2.2"
 
-"@theia/search-in-workspace@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/search-in-workspace/-/search-in-workspace-1.3.0-next.309b2189.tgz#b31ca1e484d5f0c78c04134a197d197288b92ca5"
-  integrity sha512-+h1UjWiBaZOjagOWgmvmhZyoN/mMyD3bG2edHGINwzHNOIwy0K9nbifp7KfyIA0N0cqTrYEO+iz4429B2jzTDg==
+"@theia/search-in-workspace@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/search-in-workspace/-/search-in-workspace-1.3.0-next.310ff528.tgz#061b709423845b8db76a53aaf9a343fb9e6b4879"
+  integrity sha512-aoKEcYBq+jpYg+UJDtbgFFE2ubFU25NBSN0ZHIOD0BsNJrU2sR0fHG1YbVMzNvHGDwkOHS+Clvh+NcX3DHKKeA==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/navigator" "1.3.0-next.309b2189"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/navigator" "1.3.0-next.310ff528"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     vscode-ripgrep "^1.2.4"
 
-"@theia/task@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.3.0-next.309b2189.tgz#0786c48897d792a7d83750b02fc7af529dc741b6"
-  integrity sha512-DP3a2ncktAGk0CfLgLDamZOrEbvrv4qkCTxV5QmeNp/QE/IS1nhfYx0MxBCjhqu3cbhdknRpOcApbFsk1joypg==
+"@theia/task@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.3.0-next.310ff528.tgz#13ce643ddae2494f31e0f3a90b2115328b5c7426"
+  integrity sha512-Bhu3Ng1QljtKSYe2zfSPGq+UnxTJxOnrj/sLYzY3w/zmaNUVkTejjJJDri2xD3mAXCjjfM0GbAQD3shZURX2zQ==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/markers" "1.3.0-next.309b2189"
-    "@theia/monaco" "1.3.0-next.309b2189"
-    "@theia/preferences" "1.3.0-next.309b2189"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/terminal" "1.3.0-next.309b2189"
-    "@theia/variable-resolver" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/markers" "1.3.0-next.310ff528"
+    "@theia/monaco" "1.3.0-next.310ff528"
+    "@theia/preferences" "1.3.0-next.310ff528"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/terminal" "1.3.0-next.310ff528"
+    "@theia/variable-resolver" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     ajv "^6.5.3"
     jsonc-parser "^2.0.2"
     p-debounce "^2.1.0"
 
-"@theia/terminal@1.3.0-next.309b2189", "@theia/terminal@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.3.0-next.309b2189.tgz#d8138b9e62c21dccb2738ba4171028cb293e71ca"
-  integrity sha512-6G7cdXlJ0z/WQQxzZZ4Re7zWOLXfEV/RLgns7m0vPhyxxJj0cgH5LR1NC5kCDf8rrKXziNzsR/8nHFL04vmPSw==
+"@theia/terminal@1.3.0-next.310ff528", "@theia/terminal@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.3.0-next.310ff528.tgz#d977ab88ff1a58f8bf9642af6560691e7c4742c1"
+  integrity sha512-pbgIeoDWXVevxf0LlCqeZ6kjONcPO1ZPhc58zTYkw07ai8LkW44PTbXHjqx/o4+MvflKzkouGSdaEkoOSv0xgQ==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/editor" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/process" "1.3.0-next.309b2189"
-    "@theia/workspace" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/editor" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/process" "1.3.0-next.310ff528"
+    "@theia/workspace" "1.3.0-next.310ff528"
     xterm "^4.4.0"
     xterm-addon-fit "^0.3.0"
     xterm-addon-search "^0.5.0"
 
-"@theia/userstorage@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.3.0-next.309b2189.tgz#79139ba6d9ef35bb2d1d8c31fdcf30aec4eaa4fd"
-  integrity sha512-0QGgZuzpDexfm+ikC8VfpLzKXy+fcWy5D2akr7TpBSdZ3O/L/5MvkPHw18lDLfEgLBcTN17jUunxeash5sZbVg==
+"@theia/userstorage@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.3.0-next.310ff528.tgz#76c3521cb23d4ac9b95f5b4913445104599f7fc5"
+  integrity sha512-oygZwYJ9VT5oDE3QmGfaIMQ+eF1779Ds5gFx1uRHQRbBSKjyw7T8qAGe+zF0GRbflwpXYVOxZ9PPmKUOM9HpFw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
 
-"@theia/variable-resolver@1.3.0-next.309b2189":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.3.0-next.309b2189.tgz#d1b26c9601117d324db08227da31e14bf6408529"
-  integrity sha512-aBFS2ZMq2f+PosD5Y9f1NcqBuvWkD0Wfo8aV/9WVz647G5rOU75bNfOkSEnOlL5fPlqpQMYIugQADzZstHURwg==
+"@theia/variable-resolver@1.3.0-next.310ff528":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.3.0-next.310ff528.tgz#aba3956924ac7dc0f7eeb17b57cec9c66e516faf"
+  integrity sha512-BLqJ0+fPGTuTQplLmPyfd+RtXjbJbvZR0z7TV6XFO6KHRNf7KI69imWPOjcyJ2uvknvz2i56dBlq1oBu5HkzeA==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
 
 "@theia/vsx-registry@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/vsx-registry/-/vsx-registry-1.3.0-next.309b2189.tgz#6f72a564ce9b6d2cab6d890f578c44780ee17a64"
-  integrity sha512-IHl7BDpfo7mnXNXIFFXsVMKK6uiWLHB6u37n0AC34312QSAHSmFnYofH0OeQ9nYQsMvQ2ZkFta0npoVU8ElZzA==
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/vsx-registry/-/vsx-registry-1.3.0-next.310ff528.tgz#219c26429debb2e1a57948a32a30ae4bce3c1b87"
+  integrity sha512-tcmCCWOOjpMHZuBj4UUiuIemcZqmmIpng5joWpCsAMY+lf062r3fZmuum71saW420BchPXTXBz7DFLfFW9Ag/A==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/plugin-ext-vscode" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/plugin-ext-vscode" "1.3.0-next.310ff528"
     "@types/bent" "^7.0.1"
     "@types/sanitize-html" "^1.13.31"
     "@types/showdown" "^1.7.1"
@@ -1533,14 +1558,14 @@
     showdown "^1.9.1"
     uuid "^8.0.0"
 
-"@theia/workspace@1.3.0-next.309b2189", "@theia/workspace@next":
-  version "1.3.0-next.309b2189"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.3.0-next.309b2189.tgz#7276aa00aa661c5ac9aa0d427b3dac032ecbda0f"
-  integrity sha512-Zq8EsdLe5UOm4YOi/Gp8zS10R1ZS9wIs46aTj3REff1ctyubctOHigWvGQ1/jAgzV5iYfsS1l1MMWHoAlM4yRw==
+"@theia/workspace@1.3.0-next.310ff528", "@theia/workspace@next":
+  version "1.3.0-next.310ff528"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.3.0-next.310ff528.tgz#4136ff647b3b14a2d2c756048b50c0e1fe0779b5"
+  integrity sha512-QzLocdEqraAnpaEa4h/yiOZA+yq/6oJp2j8HF9pC8iPOMRPWOJMxteXpEHgY33ZNecnj6J1NzARSIhKYArL3Aw==
   dependencies:
-    "@theia/core" "1.3.0-next.309b2189"
-    "@theia/filesystem" "1.3.0-next.309b2189"
-    "@theia/variable-resolver" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.310ff528"
+    "@theia/filesystem" "1.3.0-next.310ff528"
+    "@theia/variable-resolver" "1.3.0-next.310ff528"
     ajv "^6.5.3"
     jsonc-parser "^2.0.2"
     moment "2.24.0"
@@ -1662,9 +1687,9 @@
     "@types/node" "*"
 
 "@types/json-schema@^7.0.4":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
-  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/lodash.debounce@4.0.3":
   version "4.0.3"
@@ -1728,14 +1753,14 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "14.0.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.12.tgz#9c1d8ffb8084e8936603a6122a7649e40e68e04b"
-  integrity sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q==
+  version "14.0.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
+  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
 "@types/node@^10.12.18":
-  version "10.17.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.25.tgz#64f64cd3e8641e8163c81045e545d2825d300e37"
-  integrity sha512-EWPw3jDB0jip4HafDkoezNOwG00TtVZ1TOe74MaxIBWgpyM60UF/LXzFVx9+8AdSYNNOPgx7TuJoRmgnhHZ/7g==
+  version "10.17.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.26.tgz#a8a119960bff16b823be4c617da028570779bcfd"
+  integrity sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1774,7 +1799,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@^16.0.6":
+"@types/react-dom@^16.8.0":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
   integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
@@ -1803,10 +1828,10 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.4.1":
-  version "16.9.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
-  integrity sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==
+"@types/react@*", "@types/react@^16.8.0":
+  version "16.9.36"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.36.tgz#ade589ff51e2a903e34ee4669e05dbfa0c1ce849"
+  integrity sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -1843,9 +1868,9 @@
   integrity sha512-1AQYpsMbxangSnApsyIHzck5TP8cfas8fzmemljLi2APssJvlZiHkTar/ZtcZwOtK/Ory/xwLg2X8dwhkbnM+g==
 
 "@types/sanitize-html@^1.13.31":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.23.0.tgz#4ed2d6bdd44cb6ae027bd0a428142220da4334a7"
-  integrity sha512-yl0HvhWOZWzmkGEBQLKYf+BtotvbGLFhCejuBvwyM1Q23RliLXNfviuOMLQ/nCRFWR2yI0LRRiaH/Oz7CIpCGw==
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.23.2.tgz#6dfef987681a6469b0aeb37bc6ff370700c6c440"
+  integrity sha512-s00omSXGjemcNGXChE44grxYLPCkxdp/rdxGCb4FcGyH0aOjFOacrnP0P394Ktp+IKeBk1Q7VsGJ+cOa2GZ5hw==
   dependencies:
     htmlparser2 "^4.1.0"
 
@@ -3317,9 +3342,9 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 bent@^7.1.0:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.2.tgz#4e4b3f71e44e4eb3409b811f51a2cd5ae59818ef"
-  integrity sha512-iI9r7tiiaWX8tToVBskcfU7omPb3Z1GoLhPZ1gqJD/K8jtHlPNB9dsD2RqiLc4xYOawsCzP8psnSuILN3PK9dg==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.4.tgz#5e1dc3cc74469929dbeb5325e9646b7035b3b92b"
+  integrity sha512-Yq3IgfeoxnB+2njT7obA8NPy94l3oAKFjP4l1b0fI0yIWOJLXSpXebHc4TzhqBAS3O3mtVkQ9Po6NcSu5C1zYA==
   dependencies:
     bytesish "^0.4.1"
     caseless "~0.12.0"
@@ -3838,14 +3863,14 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30001079"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001079.tgz#b12d77d8d09fc82a6eda726c93a6eb09b5c440e1"
-  integrity sha512-FDEnaPlS5YwjUaieK8lzcLFjvv4w6dpvuZvG56XZoxwlEkRpTkVVe+tiU2Rsl4iqpf/K0hae38w7G2jwMz8Thg==
+  version "1.0.30001083"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001083.tgz#340c9efc2efafc7cea77022aa6e816fc1fd110bb"
+  integrity sha512-UORZDifiPy1KAGZ8mvTnN+0DcIxfgSALNqPZr52cIOBNjNHn5o88n3eelwpO8+ECM2LsHDorrgZBfrdPVgOhJg==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001079"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001079.tgz#ed3e5225cd9a6850984fdd88bf24ce45d69b9c22"
-  integrity sha512-2KaYheg0iOY+CMmDuAB3DHehrXhhb4OZU4KBVGDr/YKyYAcpudaiUQ9PJ9rxrPlKEoJ3ATasQ5AN48MqpwS43Q==
+  version "1.0.30001083"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001083.tgz#52410c20c6f029f604f0d45eca0439a82e712442"
+  integrity sha512-CnYJ27awX4h7yj5glfK7r1TOI13LBytpLzEgfj0s4mY75/F8pnQcYjL+oVpmS38FB59+vU0gscQ9D8tc+lIXvA==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -3905,9 +3930,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -5460,9 +5485,9 @@ electron-store@^2.0.0:
     conf "^2.0.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.413:
-  version "1.3.465"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz#d692e5c383317570c2bd82092a24a0308c6ccf29"
-  integrity sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ==
+  version "1.3.473"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.473.tgz#d0cd5fe391046fb70674ec98149f0f97609d29b8"
+  integrity sha512-smevlzzMNz3vMz6OLeeCq5HRWEj2AcgccNPYnAx4Usx0IOciq9DU36RJcICcS09hXoY7t7deRfVYKD14IrGb9A==
 
 electron@^4.2.11:
   version "4.2.12"
@@ -5579,21 +5604,21 @@ error@^7.0.2:
     string-template "~0.2.1"
 
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
-  version "1.17.5"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
-  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+  version "1.17.6"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-    is-callable "^1.1.5"
-    is-regex "^1.0.5"
+    is-callable "^1.2.0"
+    is-regex "^1.1.0"
     object-inspect "^1.7.0"
     object-keys "^1.1.1"
     object.assign "^4.1.0"
-    string.prototype.trimleft "^2.1.1"
-    string.prototype.trimright "^2.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -6210,9 +6235,9 @@ flatten@^1.0.2:
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 flow-parser@^0.*:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.126.1.tgz#963f569079e015e15475c2fcb106e49c1555a44d"
-  integrity sha512-HDQAPl2F8vuGgyVm/Zx4vmT9Ja/ACAVIWVA3FRIcNoklkWsWDv+2vv2oVLk/2n+jAzESmvA5nFc2ElayVFZN1A==
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.127.0.tgz#e23ac72f3e7d2c25a6918c6d695db9f2e6c7a913"
+  integrity sha512-T4T92hVeVtrkYYvU01L2KFANsA0TJQrgy46efIU/JBxDhVjxIdS7KzaBEsPJu7RPOM44FCR7wcFQg6rWtGGrLQ==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -7384,7 +7409,7 @@ is-buffer@^2.0.2, is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4, is-callable@^1.1.5:
+is-callable@^1.1.4, is-callable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
@@ -7623,7 +7648,7 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
-is-regex@^1.0.5:
+is-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
   integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
@@ -7770,9 +7795,9 @@ isurl@^1.0.0-alpha5:
     is-object "^1.0.1"
 
 jake@^10.6.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.1.tgz#0f6f5ef13ebe014104527fb4b1b24f44cd1f04d6"
-  integrity sha512-eSp5h9S7UFzKdQERTyF+KuPLjDZa1Tbw8gCVUn98n4PbIkLEDGe4zl7vF4Qge9kQj06HcymnksPk8jznPZeKsA==
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.2.tgz#ebc9de8558160a66d82d0eadc6a2e58fbc500a7b"
+  integrity sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==
   dependencies:
     async "0.9.x"
     chalk "^2.4.2"
@@ -10429,9 +10454,9 @@ pupa@^2.0.1:
     escape-goat "^2.0.0"
 
 puppeteer-to-istanbul@^1.2.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-to-istanbul/-/puppeteer-to-istanbul-1.3.1.tgz#9ff9e8df93053a291ad053c3a42f3e6d543f9167"
-  integrity sha512-196DFlmt2ZCdBhODxk1T5tTEZw3L4RgnxQBd5Utna92NkyM4MDweVDcypJEEMkYYOV6zhIRPdR3KNMTmVeIeJg==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-to-istanbul/-/puppeteer-to-istanbul-1.4.0.tgz#451dced6f42652448f55cf0bc780b35512c8d1b0"
+  integrity sha512-dzW8u/PMqMZppvoXCFod8IkCTI2JL0yP2YUBbaALnX+iJJ6gqjk77fIoK9MqnMqRZAcoa81GLFfZExakWg/Q4Q==
   dependencies:
     clone "^2.1.2"
     mkdirp "^1.0.4"
@@ -10567,7 +10592,7 @@ react-chartjs-2@^2.7.6:
     lodash "^4.17.4"
     prop-types "^15.5.8"
 
-react-dom@^16.4.1:
+react-dom@^16.8.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -10652,7 +10677,7 @@ react-virtualized@^9.20.0, react-virtualized@^9.21.0:
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
-react@^16.4.1:
+react@^16.8.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
@@ -11935,7 +11960,7 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimend@^1.0.0:
+string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
@@ -11943,25 +11968,7 @@ string.prototype.trimend@^1.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
-  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimstart "^1.0.0"
-
-string.prototype.trimright@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
-  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimend "^1.0.0"
-
-string.prototype.trimstart@^1.0.0:
+string.prototype.trimstart@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
@@ -13009,9 +13016,12 @@ vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next:
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
 vscode-ripgrep@^1.2.4:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.6.1.tgz#09519917f1211d9c905af1788383f9bc5f52ede9"
-  integrity sha512-ad9kgxyFWmjPGRiQTAtQ2/4qW4d7aCYAKeieafFxLPCOxEXE9dBT4pGHZassldvXQYBWZXO57NiwiRWFhIY8Ew==
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.6.2.tgz#fb912c7465699f10ce0218a6676cc632c77369b4"
+  integrity sha512-jkZEWnQFcE+QuQFfxQXWcWtDafTmgkp3DjMKawDkajZwgnDlGKpFp15ybKrZNVTi1SLEF/12BzxYSZVVZ2XrkA==
+  dependencies:
+    https-proxy-agent "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 vscode-textmate@^4.0.1:
   version "4.4.0"
@@ -13353,9 +13363,9 @@ xterm-addon-search@^0.5.0:
   integrity sha512-zLVqVTrg5w2nk9fRj3UuVKCPo/dmFe/cLf3EM9Is5Dm6cgOoXmeo9eq2KgD8A0gquAflTFTf0ya2NaFmShHwyg==
 
 xterm@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.6.0.tgz#1b49b32e546409c110fbe8ece0b4a388504a937d"
-  integrity sha512-98211RIDrAECqpsxs6gbilwMcxLtxSDIvtzZUIqP1xIByXtuccJ4pmMhHGJATZeEGe/reARPMqwPINK8T7jGZg==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.7.0.tgz#254485811146b03fbea10c911f7f68a99e1d3bfd"
+  integrity sha512-UeH6U/1iknCBP94/AcKAFBeQz6ZicMugJHGXruTmsY8RcZt+mkx+vl8jLLOqNYweXdBbywCg2kK88WDKjcmSmg==
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"7zip-bin@~5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.0.3.tgz#bc5b5532ecafd923a61f2fb097e3b108c0106a3f"
+  integrity sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
@@ -19,18 +24,18 @@
     semver "^5.5.0"
 
 "@babel/core@^7.5.5":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.1.tgz#2a0ad0ea693601820defebad2140206503d89af3"
-  integrity sha512-u8XiZ6sMXW/gPmoP5ijonSUln4unazG291X0XAQ5h0s8qnAFr6BRRZGUEK+jtRWdmB0NTJQt7Uga25q8GetIIg==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.2.tgz#bd6786046668a925ac2bd2fd95b579b92a23b36a"
+  integrity sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==
   dependencies:
     "@babel/code-frame" "^7.10.1"
-    "@babel/generator" "^7.10.1"
+    "@babel/generator" "^7.10.2"
     "@babel/helper-module-transforms" "^7.10.1"
     "@babel/helpers" "^7.10.1"
-    "@babel/parser" "^7.10.1"
+    "@babel/parser" "^7.10.2"
     "@babel/template" "^7.10.1"
     "@babel/traverse" "^7.10.1"
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.2"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
@@ -40,12 +45,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.1.tgz#4d14458e539bcb04ffe34124143f5c489f2dbca9"
-  integrity sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==
+"@babel/generator@^7.10.1", "@babel/generator@^7.10.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
+  integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
   dependencies:
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.2"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -65,10 +70,10 @@
     "@babel/helper-explode-assignable-expression" "^7.10.1"
     "@babel/types" "^7.10.1"
 
-"@babel/helper-compilation-targets@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.1.tgz#ad6f69b4c3bae955081ef914a84e5878ffcaca63"
-  integrity sha512-YuF8IrgSmX/+MV2plPkjEnzlC2wf+gaok8ehMNN0jodF3/sejZauExqpEVGbJua62oaWoNYIXwz4RmAsVcGyHw==
+"@babel/helper-compilation-targets@^7.10.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz#a17d9723b6e2c750299d2a14d4637c76936d8285"
+  integrity sha512-hYgOhF4To2UTB4LTaZepN/4Pl9LD4gfbJx8A34mqoluT8TLbof1mhUlYuNWTEebONa8+UlCC4X0TEXu7AOUyGA==
   dependencies:
     "@babel/compat-data" "^7.10.1"
     browserslist "^4.12.0"
@@ -77,9 +82,9 @@
     semver "^5.5.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.1.tgz#6d8a45aafe492378d0e6fc0b33e5dea132eae21c"
-  integrity sha512-bwhdehBJZt84HuPUcP1HaTLuc/EywVS8rc3FgsEPDcivg+DCW+SHuLHVkYOmcBA1ZfI+Z/oZjQc/+bPmIO7uAA==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz#7474295770f217dbcf288bf7572eb213db46ee67"
+  integrity sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==
   dependencies:
     "@babel/helper-function-name" "^7.10.1"
     "@babel/helper-member-expression-to-functions" "^7.10.1"
@@ -252,10 +257,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.1.tgz#2e142c27ca58aa2c7b119d09269b702c8bbad28c"
-  integrity sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==
+"@babel/parser@^7.10.1", "@babel/parser@^7.10.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
+  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.1":
   version "7.10.1"
@@ -679,12 +684,12 @@
     "@babel/helper-plugin-utils" "^7.10.1"
 
 "@babel/preset-env@^7.5.5":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.1.tgz#099e1b76379739bdcbfab3d548dc7e7edb2ac808"
-  integrity sha512-bGWNfjfXRLnqbN2T4lB3pMfoic8dkRrmHpVZamSFHzGy5xklyHTobZ28TVUD2grhE5WDnu67tBj8oslIhkiOMQ==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.2.tgz#715930f2cf8573b0928005ee562bed52fb65fdfb"
+  integrity sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==
   dependencies:
     "@babel/compat-data" "^7.10.1"
-    "@babel/helper-compilation-targets" "^7.10.1"
+    "@babel/helper-compilation-targets" "^7.10.2"
     "@babel/helper-module-imports" "^7.10.1"
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-proposal-async-generator-functions" "^7.10.1"
@@ -741,7 +746,7 @@
     "@babel/plugin-transform-unicode-escapes" "^7.10.1"
     "@babel/plugin-transform-unicode-regex" "^7.10.1"
     "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.10.1"
+    "@babel/types" "^7.10.2"
     browserslist "^4.12.0"
     core-js-compat "^3.6.2"
     invariant "^2.2.2"
@@ -760,9 +765,9 @@
     esutils "^2.0.2"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.1.tgz#b6eb75cac279588d3100baecd1b9894ea2840822"
-  integrity sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -790,14 +795,22 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.10.1", "@babel/types@^7.4.4":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.1.tgz#6886724d31c8022160a7db895e6731ca33483921"
-  integrity sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==
+"@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.4.4":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
+  integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.1"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@develar/schema-utils@~2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"
+  integrity sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==
+  dependencies:
+    ajv "^6.12.0"
+    ajv-keywords "^3.4.1"
 
 "@fortawesome/fontawesome-common-types@^0.2.28":
   version "0.2.28"
@@ -819,9 +832,9 @@
     "@fortawesome/fontawesome-common-types" "^0.2.28"
 
 "@fortawesome/react-fontawesome@^0.1.4":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz#c865b9286c707407effcec99958043711367cd02"
-  integrity sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.10.tgz#7ba2bd300036f95e2ac084000ba8ba26cd269c96"
+  integrity sha512-UGdpJiLBIqR/8xcLrCarf2pChqQFKjDTD02C7ZS/odpOVVl2YuHYRCLEOQ0GpfOk6jtYhmouSFOFoC8qNCe5cg==
   dependencies:
     prop-types "^15.7.2"
 
@@ -969,21 +982,33 @@
   dependencies:
     execa "^0.2.2"
 
+"@sindresorhus/is@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
+  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@theia/application-manager@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.3.0-next.2aa2fa1a.tgz#b7b2032f1c25c309a6e2b278f79be0421bce4a5a"
-  integrity sha512-HNsgOehCTrRjigvACweZYJYRjcGHx1ugJFfAliyJL1ZvFXG5ki+ynWbga9OKtho66c5GCC5Ut2OGyawgDWFiVQ==
+"@szmarczak/http-timer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  dependencies:
+    defer-to-connect "^1.0.1"
+
+"@theia/application-manager@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/application-manager/-/application-manager-1.3.0-next.309b2189.tgz#dfa661e9c7df3deca6fae1cff6d081aefcb79a14"
+  integrity sha512-hnfGfVU45hGFANVPYtm4DvF4m0CF5OGVzYHdGS9TMu0DIOMFQDJYlmzJ0z6H/+06zQ1B1YLa7hBBIY9UnjvRSg==
   dependencies:
     "@babel/core" "^7.5.5"
     "@babel/plugin-transform-classes" "^7.5.5"
     "@babel/plugin-transform-runtime" "^7.5.5"
     "@babel/preset-env" "^7.5.5"
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
+    "@theia/application-package" "1.3.0-next.309b2189"
     "@theia/compression-webpack-plugin" "^3.0.0"
     "@types/fs-extra" "^4.0.2"
     "@types/webpack" "^4.41.2"
@@ -1006,10 +1031,10 @@
     webpack-cli "2.0.12"
     worker-loader "^1.1.1"
 
-"@theia/application-package@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.3.0-next.2aa2fa1a.tgz#81d24700b7fedbf23013fa21cff52b6c9f726ead"
-  integrity sha512-d6pjiQnTq1xrU6LOeRUjMfptycuybqhxL6EiJMD6RXSamvusItfYG1UZfPnKai7pj/jz4ajuJNhM2tlu6upVBQ==
+"@theia/application-package@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-1.3.0-next.309b2189.tgz#e3e0bb2b7e5e44460daa4a1ba8b30510b793f9b5"
+  integrity sha512-HBuCfVYV7siSDJ5i7d4QUZDwuBpJ4inyCBfLRlNuSH3Vo+7L9DCL6Ul7bHjORo58yOUdoOYV1eXGdDYvi+r8EQ==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -1022,13 +1047,24 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/cli@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.3.0-next.2aa2fa1a.tgz#d85ce5c25795021728fc1e19b3fc4d5eec332767"
-  integrity sha512-J+of8WYsPljwkuqLXIF2Z9m086Xsp2R+Td+KbmSPp1pdW8fIhMb2QL3Yc3mNz7YmO8+kTsZgdvJnjyL8ohpNLA==
+"@theia/callhierarchy@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/callhierarchy/-/callhierarchy-1.3.0-next.309b2189.tgz#f761fb2abc04d2204bafed5ca496f615dad65cde"
+  integrity sha512-1u7UE7LImHS8IU5i3xaLCU+7qxCzHLVxJHibMLjGCcNZS3CaPZkgINBZdJ7ypT3qr2Nwn/5tM1BYtCuSnJYtVA==
   dependencies:
-    "@theia/application-manager" "1.3.0-next.2aa2fa1a"
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/languages" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    ts-md5 "^1.2.2"
+
+"@theia/cli@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/cli/-/cli-1.3.0-next.309b2189.tgz#f97b6152bfb89c5120cedaf93d852f895cb675e7"
+  integrity sha512-QJGCBwtY+ANaKbaisZLoUi63BDU6r4L1MbRAFMaGpmGDoUpUsHXyRmKyf2jEzyE4loE6ziG+7d/W94/YBBw64w==
+  dependencies:
+    "@theia/application-manager" "1.3.0-next.309b2189"
+    "@theia/application-package" "1.3.0-next.309b2189"
     "@types/chai" "^4.2.7"
     "@types/mkdirp" "^0.5.2"
     "@types/mocha" "^5.2.7"
@@ -1061,24 +1097,24 @@
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
 
-"@theia/console@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.3.0-next.2aa2fa1a.tgz#21afdba58b1dc8cd49b6cf9fea104ebfa875eba6"
-  integrity sha512-H+CNQcPwvkHPLfUPIcq8WFZJUUJ2W9QTzLgwno6xcW++32+Lxnj4bn2zaRQ0dpvEIlD1jwnHcrnScPFgfbX9Tg==
+"@theia/console@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/console/-/console-1.3.0-next.309b2189.tgz#d207a4a95927445e531f926e4196c1b5df34930e"
+  integrity sha512-SGP2aWENy74hSubmb/75ausKSlCUbreD6hfWKjK3xOJ+H60Uj6fGEAIgDy6yTFFNp68qAa8CWt3o/9Yqhfum3Q==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/monaco" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
     anser "^1.4.7"
 
-"@theia/core@1.3.0-next.2aa2fa1a", "@theia/core@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.3.0-next.2aa2fa1a.tgz#d0551fa316ca787e4aaba4d3e358ae0c5e176c4e"
-  integrity sha512-g8kEuhVXmsdVStqCbxgmbAMQRoUkXSnarxWkKaLeP96l4nEFaBOcyfzEjpC8GUyYnCJ+1vYqRB/HYlFC9TBgbA==
+"@theia/core@1.3.0-next.309b2189", "@theia/core@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.3.0-next.309b2189.tgz#3a64817306d87fdb3d67e0d42477c241f7a565eb"
+  integrity sha512-JrmTamN4tEJsILmHRGakZBPHveBqgbybg7BG8cilXi/0amYfw5qKn8oALUKlpTfJ4F9bew5REb1hCxpW4GO6mg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@phosphor/widgets" "^1.9.3"
     "@primer/octicons-react" "^9.0.0"
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
+    "@theia/application-package" "1.3.0-next.309b2189"
     "@types/body-parser" "^1.16.4"
     "@types/cookie" "^0.3.3"
     "@types/express" "^4.16.0"
@@ -1128,44 +1164,27 @@
     ajv "^6.5.3"
     lodash "^4.17.10"
 
-"@theia/cpp@next":
-  version "1.1.0-next.184f7751"
-  resolved "https://registry.yarnpkg.com/@theia/cpp/-/cpp-1.1.0-next.184f7751.tgz#96c5ca20d24e1285599d2decfa425d1100f6c8e9"
-  integrity sha512-TAp0TS5YCUl1z3Avl7BrZF/LrZZmbbR+oMyeOwauVKkoc05k1+fKiH8qVVLeWPkvTmnAKfB/rVxVnmCKLE+O5w==
+"@theia/debug@1.3.0-next.309b2189", "@theia/debug@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.3.0-next.309b2189.tgz#f113d7d365ccc450ebe67a092a9a827a2385f44a"
+  integrity sha512-rSgl2NSzorMJ4r7q+GafFlmpzzK+R3p1jdKKXbB8I81JSnm4hNTHDgLoUXEgVKwUJQRaOCj9H6C9YfJzdt/1WA==
   dependencies:
-    "@theia/core" next
-    "@theia/editor" next
-    "@theia/filesystem" next
-    "@theia/languages" next
-    "@theia/monaco" next
-    "@theia/preferences" next
-    "@theia/process" next
-    "@theia/task" next
-    "@theia/variable-resolver" next
-    "@theia/workspace" next
-    string-argv "^0.1.1"
-
-"@theia/debug@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/debug/-/debug-1.3.0-next.2aa2fa1a.tgz#9230d0dd30ba10fb7bf2805e75f1331e6aba1518"
-  integrity sha512-W395yJCyLJlvu8Xk4QAQGxNczJDHs3kJ5d7zw3XRCZdq0U+4tnwksknJ2dSpBaw7ZT6BI+WqDfhHGwWtoVpD8A==
-  dependencies:
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
-    "@theia/console" "1.3.0-next.2aa2fa1a"
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/editor" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/languages" "1.3.0-next.2aa2fa1a"
-    "@theia/markers" "1.3.0-next.2aa2fa1a"
-    "@theia/monaco" "1.3.0-next.2aa2fa1a"
-    "@theia/output" "1.3.0-next.2aa2fa1a"
-    "@theia/preferences" "1.3.0-next.2aa2fa1a"
-    "@theia/process" "1.3.0-next.2aa2fa1a"
-    "@theia/task" "1.3.0-next.2aa2fa1a"
-    "@theia/terminal" "1.3.0-next.2aa2fa1a"
-    "@theia/userstorage" "1.3.0-next.2aa2fa1a"
-    "@theia/variable-resolver" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/console" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/languages" "1.3.0-next.309b2189"
+    "@theia/markers" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/output" "1.3.0-next.309b2189"
+    "@theia/preferences" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/task" "1.3.0-next.309b2189"
+    "@theia/terminal" "1.3.0-next.309b2189"
+    "@theia/userstorage" "1.3.0-next.309b2189"
+    "@theia/variable-resolver" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     jsonc-parser "^2.0.2"
     mkdirp "^0.5.0"
     p-debounce "^2.1.0"
@@ -1174,21 +1193,21 @@
     unzip-stream "^0.3.0"
     vscode-debugprotocol "^1.32.0"
 
-"@theia/editor@1.3.0-next.2aa2fa1a", "@theia/editor@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.3.0-next.2aa2fa1a.tgz#d4f16b3db371ba59c30940e5f1cdcf27dd19fcb5"
-  integrity sha512-6SCzYT0ZpasvffQ4CUT21mjUH8NVw0ECepIgyLJghhnqU1UlhWNYBIwD+KO4PhjC7HW6H5tVpNLIYqq9jGfACg==
+"@theia/editor@1.3.0-next.309b2189", "@theia/editor@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-1.3.0-next.309b2189.tgz#e8ed81890cd6b68f83028a1f540a6ade608a9519"
+  integrity sha512-WkOkzk0a8po8z2p4Vi8O84HrVa1eDmVx4eotSpdqrZQqUR6xpf/UrrSrdB4IyC2jmN3NuxhenAXkROM08BkkcQ==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/languages" "1.3.0-next.2aa2fa1a"
-    "@theia/variable-resolver" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/languages" "1.3.0-next.309b2189"
+    "@theia/variable-resolver" "1.3.0-next.309b2189"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
 "@theia/electron@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/electron/-/electron-1.3.0-next.2aa2fa1a.tgz#7f34a076a31ad23becbf8324c146dc3833e2629a"
-  integrity sha512-vHuNGHwSlGLFOTLWYhBNXMfDvKc23glMO648A0bD+dvvrSV5NA21+mYhhNl95VdDT0mkgLXJvLNQfkgv/YfKDQ==
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/electron/-/electron-1.3.0-next.309b2189.tgz#306e83f2c080bde730920641aa0849f629489382"
+  integrity sha512-so1Bp0HkTCZ0uevdib436u+9iwPo7cJDo+RS8KArZD6efTTLnPxUrYB8ikKYUq4WFoUJogk5v+/r4vzC/PhTHg==
   dependencies:
     electron "^4.2.11"
     electron-download "^4.1.1"
@@ -1199,13 +1218,26 @@
     unzipper "^0.9.11"
     yargs "^11.1.0"
 
-"@theia/filesystem@1.3.0-next.2aa2fa1a", "@theia/filesystem@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.3.0-next.2aa2fa1a.tgz#766407d39a6f995f42614718a337cb4b0f308717"
-  integrity sha512-mb1J+glkIBEvxKkEaaa1gtCHjPBhhY4xyu/9zkAXGUsYbs9G1lWqxvBecHUhDv01EWd4LkAZaLgX5UeB1jiArw==
+"@theia/file-search@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-1.3.0-next.309b2189.tgz#925d73ad59347bb8e2f96454710b2f96266206f3"
+  integrity sha512-4O2Xl6CfV+Xg9Jp2a/Ti+QZutT3awI809AVyewrjm2RxXDl8q9uQteXwDz4xrFGj6twywcumMgKnaDyhLR6NBw==
   dependencies:
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
+    fuzzy "^0.1.3"
+    vscode-ripgrep "^1.2.4"
+
+"@theia/filesystem@1.3.0-next.309b2189", "@theia/filesystem@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.3.0-next.309b2189.tgz#a9d76337485135cbdb6bd3b0ea1057b394835c98"
+  integrity sha512-+L3yg6XpClT5oRqv3mi9/F5thhkqnjZxs3i3uH6JEXYtULEsGPAWLl/rbj30D0jkUTaNyxH8V58Tv9CNJy8cxw==
+  dependencies:
+    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.309b2189"
     "@types/body-parser" "^1.17.0"
     "@types/rimraf" "^2.0.2"
     "@types/tar-fs" "^1.16.1"
@@ -1225,37 +1257,36 @@
     uuid "^8.0.0"
     zip-dir "^1.0.2"
 
-"@theia/languages@1.3.0-next.2aa2fa1a", "@theia/languages@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-1.3.0-next.2aa2fa1a.tgz#26f2bfea94afebbcf61a21618988ea884d717e12"
-  integrity sha512-oW01ewSN4YalKX7iW0oEdFHVhaddwoq0c908Pv9bcUE00qjWOSl7pqk6YJFtOugI4T8b2o3PF+JvceJUomAfqw==
+"@theia/languages@1.3.0-next.309b2189", "@theia/languages@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-1.3.0-next.309b2189.tgz#5c1b6a30b0eb7d7b753d039a7a0c004d65c71a90"
+  integrity sha512-2m2GrMaNdjJc02jmzetyfXqLLkiAhisDBmqGZnuXWg3IMkUPYeIiJsQNC/2u1t3EmNa4AxYqn0wlwKGEj7Xohw==
   dependencies:
-    "@theia/application-package" "1.3.0-next.2aa2fa1a"
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/application-package" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.309b2189"
     "@theia/monaco-editor-core" "^0.19.3"
-    "@theia/output" "1.3.0-next.2aa2fa1a"
-    "@theia/process" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     "@types/uuid" "^7.0.3"
     monaco-languageclient "^0.13.0"
     uuid "^8.0.0"
 
-"@theia/markers@1.3.0-next.2aa2fa1a", "@theia/markers@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.3.0-next.2aa2fa1a.tgz#d50b20aa5764c572d10ae1fbf06ae05005cf19d9"
-  integrity sha512-mWWzFEKBlnnLlUrwlMkD9YagAg0fE101Id1F+LOD7hFvs8rY1htagmv86vsisT3pTCkKcgTP0Ua+lpPUYmvR4g==
+"@theia/markers@1.3.0-next.309b2189", "@theia/markers@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-1.3.0-next.309b2189.tgz#fb0a7c5d0604be3c7c15cc4eb283d53d96b0a1e3"
+  integrity sha512-hAKRzxRdJbWNgaCzrciQ8tF/aRmHG3zPW3yVPX+FgqgiOPJYoZZTz28WZLeR/ZdXvRxMGH7Sf4GSq+cH+xAH4A==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/navigator" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/navigator" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
 
-"@theia/messages@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.3.0-next.2aa2fa1a.tgz#03307c32257944c877f10c3f0a8cd1c97635f5c3"
-  integrity sha512-hg1Fgyx7QK1DvnTgQH5lOET+I1oqkjsr1njGeQYyVOJZuBpHajUkJovAf2+BYjUsFJeG6CJbGuft37I7403T/w==
+"@theia/messages@1.3.0-next.309b2189", "@theia/messages@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.3.0-next.309b2189.tgz#21e56e227c2c50366a44482d52beb865ede00cda"
+  integrity sha512-6CO718bam7cMtBPaUoA6LFBXn/DWD9tIR4RnTSltZAtyNcjmZs6G+9j2lpbHNYEKYdd0FW53jrfRvsm9kJokZw==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
     lodash.throttle "^4.1.1"
     markdown-it "^8.4.0"
     react-perfect-scrollbar "^1.5.3"
@@ -1266,18 +1297,18 @@
   resolved "https://registry.yarnpkg.com/@theia/monaco-editor-core/-/monaco-editor-core-0.19.3.tgz#8456aaa52f4cdc87c78697a0edfcccb9696a374d"
   integrity sha512-+2I5pvbK9qxWs+bLFUwto8nYubyI759/p0z86r2w0HnFdcMQ6rcqvcTupO/Cd/YAJ1/IU38PBWS7hwIoVnvCsQ==
 
-"@theia/monaco@1.3.0-next.2aa2fa1a", "@theia/monaco@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.3.0-next.2aa2fa1a.tgz#54076ac5b38a2deadfbbf37cacac23a72502fcdc"
-  integrity sha512-bT8nT5DuZ4HXf811EgtbzU5tI8P9K+KUVZ13a/rlgkiAICWo8qzLCTXp7pXzX2R34RseP4nMIHdXx5wnmMhJ7Q==
+"@theia/monaco@1.3.0-next.309b2189", "@theia/monaco@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-1.3.0-next.309b2189.tgz#3fa0785e03953b0300019f7f7aea4c10a6d3f509"
+  integrity sha512-AtbMK4GvPW4w2ZxcOlHidDEk/CPr80koSjR9s3Eqy9dMdLYRBosR+LckrfYDuIjTUkIjZ5Wy/cuqJK2N5By2Sw==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/editor" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/languages" "1.3.0-next.2aa2fa1a"
-    "@theia/markers" "1.3.0-next.2aa2fa1a"
-    "@theia/outline-view" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/languages" "1.3.0-next.309b2189"
+    "@theia/markers" "1.3.0-next.309b2189"
+    "@theia/outline-view" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     deepmerge "2.0.1"
     fast-plist "^0.1.2"
     idb "^4.0.5"
@@ -1287,14 +1318,14 @@
     onigasm "^2.2.0"
     vscode-textmate "^4.0.1"
 
-"@theia/navigator@1.3.0-next.2aa2fa1a", "@theia/navigator@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.3.0-next.2aa2fa1a.tgz#6f707704d8eb1ce8d477e9391c232e331db4d020"
-  integrity sha512-CxI4A2QTGMq80AcFx7RNTJYRkDFQh1jDAKkcXRCmSwqa7OjLokBaUaALUz7cjEHWI9hXwf/tWwfn9CW+oj+EUg==
+"@theia/navigator@1.3.0-next.309b2189", "@theia/navigator@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-1.3.0-next.309b2189.tgz#a2094ed3219327296411eee6d04163e538fc8259"
+  integrity sha512-hQ/d1uuqMDOtHIgfnb8EkZseA+0/jCwiRzulRiTak7qzhozO+h6cXGpRkglyvvYiZ/2YwClEdsQwWQ9jBCktwQ==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
@@ -1305,98 +1336,211 @@
   dependencies:
     nan "^2.14.0"
 
-"@theia/outline-view@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.3.0-next.2aa2fa1a.tgz#0b6867ac7c40aaf4af2ab68f16f2dd7086bdd1f9"
-  integrity sha512-LSmFajxDY0Ffz5ptfWv0hfgmPhqEbSkixC8QE8z1jKBe3ltdoGWnDRa9qZlEdBcG3RPldS9cTn2ShjGfR5mECA==
+"@theia/outline-view@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-1.3.0-next.309b2189.tgz#1b6f16a88a9f09966902be6a02c51599cc7a35ff"
+  integrity sha512-qbwMpB4TVUnz8FcEPOTOW2VMBKW+Nk4Jx++yP5Bx25UsOGeV+v5tlD726yDcTE+DFCWoOIghx5DMUEyr56CZEg==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
 
-"@theia/output@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.3.0-next.2aa2fa1a.tgz#6c4eac7475134b2434cfb32b8dd0f02e81661fab"
-  integrity sha512-tjJ4D+LU8ukpEpLr5e2zs99OnI4IVsqcfh+4/WJLOW7cBUqvmBA7z3A9vBMDpT862R7EM+Y8cExT/AZ+4exnTw==
+"@theia/output@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-1.3.0-next.309b2189.tgz#cfbafba7cb86ebfbf9d30941cb03715a3bf60afa"
+  integrity sha512-QCqb2SK5Mo8ixCp8/62XlxFdjBqyQ/ahcEBn40ClrYlKnl+NmC5LRMYbF8bBaluIOV019LmeIPBBzwSj/OMygg==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@types/p-queue" "^2.3.1"
+    p-queue "^2.4.2"
 
-"@theia/preferences@1.3.0-next.2aa2fa1a", "@theia/preferences@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.3.0-next.2aa2fa1a.tgz#3debdaf0a59c13dec2159f0e894e8ab1ffa54d08"
-  integrity sha512-1AgEvOzwGoGI7rLY8Ex2/ewWsyaldFIWujCN2/dfXJM68LySTstvN/nDesRwHS8Ajq2EMjHoKKes/6HMPkwUFQ==
+"@theia/plugin-ext-vscode@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext-vscode/-/plugin-ext-vscode-1.3.0-next.309b2189.tgz#faffdc3f5835c4e6f5af78ee459bace0dc4bcf35"
+  integrity sha512-m5rHRi3LBsNraSwX5vEBnh/oz43ytayGTPq5P0Mj7hON+m2dSSeLOF9CM0mxANJcVF8RNrYnMuX8fCDgGzB8NQ==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/editor" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/monaco" "1.3.0-next.2aa2fa1a"
-    "@theia/userstorage" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/plugin" "1.3.0-next.309b2189"
+    "@theia/plugin-ext" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
+    "@types/request" "^2.0.3"
+    filenamify "^4.1.0"
+    request "^2.82.0"
+
+"@theia/plugin-ext@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/plugin-ext/-/plugin-ext-1.3.0-next.309b2189.tgz#6d749fcc733661a022a3caf2f05cb224bfc3f179"
+  integrity sha512-dvIZSwsY6QT97smHHGyzHo+zERndXb2hXOlicPje1AsjoX018OJAPfuzwD7ZpFQwJpZPY/A3x4GH+cQHrw4DtQ==
+  dependencies:
+    "@theia/callhierarchy" "1.3.0-next.309b2189"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/debug" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/file-search" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/languages" "1.3.0-next.309b2189"
+    "@theia/markers" "1.3.0-next.309b2189"
+    "@theia/messages" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/navigator" "1.3.0-next.309b2189"
+    "@theia/output" "1.3.0-next.309b2189"
+    "@theia/plugin" "1.3.0-next.309b2189"
+    "@theia/preferences" "1.3.0-next.309b2189"
+    "@theia/scm" "1.3.0-next.309b2189"
+    "@theia/search-in-workspace" "1.3.0-next.309b2189"
+    "@theia/task" "1.3.0-next.309b2189"
+    "@theia/terminal" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
+    "@types/connect" "^3.4.32"
+    "@types/mime" "^2.0.1"
+    "@types/serve-static" "^1.13.3"
+    connect "^3.7.0"
+    decompress "4.2.0"
+    escape-html "^1.0.3"
+    filenamify "^4.1.0"
+    jsonc-parser "^2.0.2"
+    lodash.clonedeep "^4.5.0"
+    macaddress "^0.2.9"
+    mime "^2.4.4"
+    ps-tree "^1.2.0"
+    request "^2.82.0"
+    serve-static "^1.14.1"
+    uuid "^8.0.0"
+    vhost "^3.0.2"
+    vscode-debugprotocol "^1.32.0"
+    vscode-textmate "^4.0.1"
+
+"@theia/plugin@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/plugin/-/plugin-1.3.0-next.309b2189.tgz#bd7e23b7a7d97b2bf83133d786118feee153bd14"
+  integrity sha512-/E6YjRlW9vnl4C2TqMOlHHnMjJNc33V14fSS/vmF7rcHJRugVDh61c5hBNOI6GvgLedPXqjYgGh9bKRwaVyLKw==
+
+"@theia/preferences@1.3.0-next.309b2189", "@theia/preferences@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-1.3.0-next.309b2189.tgz#b3d4942bd707dcfeb26cd1d11f97d928a64f7f43"
+  integrity sha512-4udY9FybAY+888EduhYQABp2ua5ugaHKqY1BFYnpFoqUdcll6OEEly+VL9KbJ3bTIQkbjIIZzoDZ28wQXAu6bQ==
+  dependencies:
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/userstorage" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     jsonc-parser "^2.0.2"
 
-"@theia/process@1.3.0-next.2aa2fa1a", "@theia/process@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.3.0-next.2aa2fa1a.tgz#ffdbe81b92fd85a7c42dd94068b34885611286e9"
-  integrity sha512-2M6ui/8SJgnJ1T2nLI8+0fSEDymeW3DpcRnfz6MnUDUF/Nsq6VpNpOHoFetcDulxsJUTH0ANMRDSWRZ3lV/Scw==
+"@theia/process@1.3.0-next.309b2189", "@theia/process@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.3.0-next.309b2189.tgz#3a8e30ad57b26e9848af636556a91478d98ec74f"
+  integrity sha512-xWQBvwQas/UU0jyslRWxYpccejN3YwYNDDtou5VGUEuPMO4aZwgseIJzpGpw1ZKoiuMUVdwv46eylfmhwPa/Hw==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
     "@theia/node-pty" "0.9.0-theia.6"
     string-argv "^0.1.1"
 
-"@theia/task@1.3.0-next.2aa2fa1a", "@theia/task@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.3.0-next.2aa2fa1a.tgz#b03b2e0a405e7047b690aa14995af0b848b10b64"
-  integrity sha512-//UnjhY2PITfP0hGgOgG42kBunbJmrU9L3lOh/x6I6WF8r6bSYCdPul6tpS7CibZNJOWlM+avRfSwFqAkwtlFw==
+"@theia/scm@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/scm/-/scm-1.3.0-next.309b2189.tgz#878306d0b7a577785c918bb8ad8ec9081f02d819"
+  integrity sha512-4YnVQfhw/x6Gw2S1Q/zKlCAeBVycD+0hSmgiX1R17nEOfSH4Is9RdIhxvGdXnYazWjVmaQQ69Om+lKJvjR3Okw==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/editor" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/markers" "1.3.0-next.2aa2fa1a"
-    "@theia/monaco" "1.3.0-next.2aa2fa1a"
-    "@theia/preferences" "1.3.0-next.2aa2fa1a"
-    "@theia/process" "1.3.0-next.2aa2fa1a"
-    "@theia/terminal" "1.3.0-next.2aa2fa1a"
-    "@theia/variable-resolver" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/navigator" "1.3.0-next.309b2189"
+    "@types/diff" "^3.2.2"
+    diff "^3.4.0"
+    p-debounce "^2.1.0"
+    react-autosize-textarea "^7.0.0"
+    ts-md5 "^1.2.2"
+
+"@theia/search-in-workspace@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/search-in-workspace/-/search-in-workspace-1.3.0-next.309b2189.tgz#b31ca1e484d5f0c78c04134a197d197288b92ca5"
+  integrity sha512-+h1UjWiBaZOjagOWgmvmhZyoN/mMyD3bG2edHGINwzHNOIwy0K9nbifp7KfyIA0N0cqTrYEO+iz4429B2jzTDg==
+  dependencies:
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/navigator" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
+    vscode-ripgrep "^1.2.4"
+
+"@theia/task@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/task/-/task-1.3.0-next.309b2189.tgz#0786c48897d792a7d83750b02fc7af529dc741b6"
+  integrity sha512-DP3a2ncktAGk0CfLgLDamZOrEbvrv4qkCTxV5QmeNp/QE/IS1nhfYx0MxBCjhqu3cbhdknRpOcApbFsk1joypg==
+  dependencies:
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/markers" "1.3.0-next.309b2189"
+    "@theia/monaco" "1.3.0-next.309b2189"
+    "@theia/preferences" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/terminal" "1.3.0-next.309b2189"
+    "@theia/variable-resolver" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     ajv "^6.5.3"
     jsonc-parser "^2.0.2"
     p-debounce "^2.1.0"
 
-"@theia/terminal@1.3.0-next.2aa2fa1a", "@theia/terminal@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.3.0-next.2aa2fa1a.tgz#dcba23003b41de5439eac60edc66b6d01a35b7f3"
-  integrity sha512-wKlWFSWm31s+L7z+PrkaRED2YQYFAFkwAiDYeVJAMKB7gUyjdSlAiCAetHLYcf+uv5SeJN5ASAZ9q5z3gVxgUw==
+"@theia/terminal@1.3.0-next.309b2189", "@theia/terminal@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/terminal/-/terminal-1.3.0-next.309b2189.tgz#d8138b9e62c21dccb2738ba4171028cb293e71ca"
+  integrity sha512-6G7cdXlJ0z/WQQxzZZ4Re7zWOLXfEV/RLgns7m0vPhyxxJj0cgH5LR1NC5kCDf8rrKXziNzsR/8nHFL04vmPSw==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/editor" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/process" "1.3.0-next.2aa2fa1a"
-    "@theia/workspace" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/editor" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/process" "1.3.0-next.309b2189"
+    "@theia/workspace" "1.3.0-next.309b2189"
     xterm "^4.4.0"
     xterm-addon-fit "^0.3.0"
     xterm-addon-search "^0.5.0"
 
-"@theia/userstorage@1.3.0-next.2aa2fa1a":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.3.0-next.2aa2fa1a.tgz#210ae3b28dff1d28956b062c0ed618d1915fd053"
-  integrity sha512-vXQ/bPs1czj341bhmiWik0dDuj7yyErYq9eXM4raDgpEPo4XHFO9P6bP8R86rihZYgNFZ3mNMGT4yTl1XFmQPA==
+"@theia/userstorage@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-1.3.0-next.309b2189.tgz#79139ba6d9ef35bb2d1d8c31fdcf30aec4eaa4fd"
+  integrity sha512-0QGgZuzpDexfm+ikC8VfpLzKXy+fcWy5D2akr7TpBSdZ3O/L/5MvkPHw18lDLfEgLBcTN17jUunxeash5sZbVg==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
 
-"@theia/variable-resolver@1.3.0-next.2aa2fa1a", "@theia/variable-resolver@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.3.0-next.2aa2fa1a.tgz#18574ff61ae05dd942db5fc1bb1e226a755feb72"
-  integrity sha512-bW0J+Vui6PTBkGjJkFsaNZBmu+qnK5zgxdNyxPUXZkNUgIyC5taxGxB7XdHeppfz1Zccy2ZL4/iiQpv+gmgKKw==
+"@theia/variable-resolver@1.3.0-next.309b2189":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-1.3.0-next.309b2189.tgz#d1b26c9601117d324db08227da31e14bf6408529"
+  integrity sha512-aBFS2ZMq2f+PosD5Y9f1NcqBuvWkD0Wfo8aV/9WVz647G5rOU75bNfOkSEnOlL5fPlqpQMYIugQADzZstHURwg==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
 
-"@theia/workspace@1.3.0-next.2aa2fa1a", "@theia/workspace@next":
-  version "1.3.0-next.2aa2fa1a"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.3.0-next.2aa2fa1a.tgz#971139aba932ae74fcc9ccf69f3fe5f94859d95e"
-  integrity sha512-RqeUsMzoAtI/cVOaOqHSYSgzQoSRy6quJsz1i+75N13LCXz6sJcZj7bLLpIiWELaxYqyjxe0vgoC9E+EXqEBWQ==
+"@theia/vsx-registry@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/vsx-registry/-/vsx-registry-1.3.0-next.309b2189.tgz#6f72a564ce9b6d2cab6d890f578c44780ee17a64"
+  integrity sha512-IHl7BDpfo7mnXNXIFFXsVMKK6uiWLHB6u37n0AC34312QSAHSmFnYofH0OeQ9nYQsMvQ2ZkFta0npoVU8ElZzA==
   dependencies:
-    "@theia/core" "1.3.0-next.2aa2fa1a"
-    "@theia/filesystem" "1.3.0-next.2aa2fa1a"
-    "@theia/variable-resolver" "1.3.0-next.2aa2fa1a"
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/plugin-ext-vscode" "1.3.0-next.309b2189"
+    "@types/bent" "^7.0.1"
+    "@types/sanitize-html" "^1.13.31"
+    "@types/showdown" "^1.7.1"
+    bent "^7.1.0"
+    fs-extra "^4.0.2"
+    p-debounce "^2.1.0"
+    requestretry "^3.1.0"
+    sanitize-html "^1.14.1"
+    showdown "^1.9.1"
+    uuid "^8.0.0"
+
+"@theia/workspace@1.3.0-next.309b2189", "@theia/workspace@next":
+  version "1.3.0-next.309b2189"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.3.0-next.309b2189.tgz#7276aa00aa661c5ac9aa0d427b3dac032ecbda0f"
+  integrity sha512-Zq8EsdLe5UOm4YOi/Gp8zS10R1ZS9wIs46aTj3REff1ctyubctOHigWvGQ1/jAgzV5iYfsS1l1MMWHoAlM4yRw==
+  dependencies:
+    "@theia/core" "1.3.0-next.309b2189"
+    "@theia/filesystem" "1.3.0-next.309b2189"
+    "@theia/variable-resolver" "1.3.0-next.309b2189"
     ajv "^6.5.3"
     jsonc-parser "^2.0.2"
     moment "2.24.0"
@@ -1411,6 +1555,13 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
   integrity sha512-oyV0CGER7tX6OlfnLfGze0XbsA7tfRuTtsQ2JbP8K5KBUzc24yoYRD+0XjMRQgOejvZWeIbtkNaHlE8akzj4aQ==
+
+"@types/bent@^7.0.1":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/bent/-/bent-7.0.2.tgz#ff3ab6d2112e08b6b22b2e1582ca182c5de090bf"
+  integrity sha512-ppRvU9y5oD33ylKNnLEeQx7PNizULq9XUwZT7tMZKZ5e5MYoNruP92poHv3zCsJtWFwB8pGgntHI6YbyOAZB0Q==
+  dependencies:
+    "@types/node" "*"
 
 "@types/body-parser@*", "@types/body-parser@^1.16.4", "@types/body-parser@^1.17.0":
   version "1.19.0"
@@ -1442,7 +1593,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/connect@*":
+"@types/connect@*", "@types/connect@^3.4.32":
   version "3.4.33"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
@@ -1453,6 +1604,16 @@
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
+"@types/diff@^3.2.2":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.5.3.tgz#7c6c3721ba454d838790100faf7957116ee7deab"
+  integrity sha512-YrLagYnL+tfrgM7bQ5yW34pi5cg9pmh5Gbq2Lmuuh+zh0ZjmK2fU3896PtlpJT3IDG2rdkoG30biHJepgIsMnw==
 
 "@types/events@*":
   version "3.0.0"
@@ -1485,14 +1646,25 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@*", "@types/glob@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
-  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+"@types/fs-extra@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.1.tgz#91c8fc4c51f6d5dbe44c2ca9ab09310bd00c7918"
+  integrity sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==
   dependencies:
-    "@types/events" "*"
+    "@types/node" "*"
+
+"@types/glob@*", "@types/glob@^7.1.1":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.2.tgz#06ca26521353a545d94a0adc74f38a59d232c987"
+  integrity sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==
+  dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/json-schema@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/lodash.debounce@4.0.3":
   version "4.0.3"
@@ -1509,16 +1681,16 @@
     "@types/lodash" "*"
 
 "@types/lodash@*", "@types/lodash@^4.14.142":
-  version "4.14.153"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.153.tgz#5cb7dded0649f1df97938ac5ffc4f134e9e9df98"
-  integrity sha512-lYniGRiRfZf2gGAR9cfRC3Pi5+Q1ziJCKqPmjZocigrSJUVPWf7st1BtSJ8JOeK0FLXVndQ1IjUjTco9CXGo/Q==
+  version "4.14.155"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
+  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
 
 "@types/mime-types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
   integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
 
-"@types/mime@*":
+"@types/mime@*", "@types/mime@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.2.tgz#857a118d8634c84bba7ae14088e4508490cd5da5"
   integrity sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==
@@ -1556,19 +1728,24 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "14.0.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.5.tgz#3d03acd3b3414cf67faf999aed11682ed121f22b"
-  integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
+  version "14.0.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.12.tgz#9c1d8ffb8084e8936603a6122a7649e40e68e04b"
+  integrity sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q==
 
 "@types/node@^10.12.18":
-  version "10.17.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
-  integrity sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==
+  version "10.17.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.25.tgz#64f64cd3e8641e8163c81045e545d2825d300e37"
+  integrity sha512-EWPw3jDB0jip4HafDkoezNOwG00TtVZ1TOe74MaxIBWgpyM60UF/LXzFVx9+8AdSYNNOPgx7TuJoRmgnhHZ/7g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/p-queue@^2.3.1":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
+  integrity sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ==
 
 "@types/pixi.js@^4.8.2":
   version "4.8.9"
@@ -1665,18 +1842,30 @@
   resolved "https://registry.yarnpkg.com/@types/route-parser/-/route-parser-0.1.3.tgz#f8af16886ebe0b525879628c04f81433ac617af0"
   integrity sha512-1AQYpsMbxangSnApsyIHzck5TP8cfas8fzmemljLi2APssJvlZiHkTar/ZtcZwOtK/Ory/xwLg2X8dwhkbnM+g==
 
+"@types/sanitize-html@^1.13.31":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.23.0.tgz#4ed2d6bdd44cb6ae027bd0a428142220da4334a7"
+  integrity sha512-yl0HvhWOZWzmkGEBQLKYf+BtotvbGLFhCejuBvwyM1Q23RliLXNfviuOMLQ/nCRFWR2yI0LRRiaH/Oz7CIpCGw==
+  dependencies:
+    htmlparser2 "^4.1.0"
+
 "@types/semver@^5.4.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
   integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
 
-"@types/serve-static@*":
+"@types/serve-static@*", "@types/serve-static@^1.13.3":
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.4.tgz#6662a93583e5a6cabca1b23592eb91e12fa80e7c"
   integrity sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/showdown@^1.7.1":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@types/showdown/-/showdown-1.9.3.tgz#eaa881b03a32d3720184731754d3025fc450b970"
+  integrity sha512-akvzSmrvY4J5d3tHzUUiQr0xpjd4Nb3uzWW6dtwzYJ+qW/KdWw5F8NLatnor5q/1LURHnzDA1ReEwCVqcatRnw==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -1734,18 +1923,18 @@
   integrity sha512-WGZCqBZZ0mXN2RxvLHL6/7RCu+OWs28jgQMP04LWfpyJlQUMTR6YU9CNJAKDgbw+EV/u687INXuLUc7FuML/4g==
 
 "@types/webpack-sources@*":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"
-  integrity sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-1.4.0.tgz#e58f1f05f87d39a5c64cf85705bdbdbb94d4d57e"
+  integrity sha512-c88dKrpSle9BtTqR6ifdaxu1Lvjsl3C5OsfvuUbUwdXymshv1TkufUAXBajCCUM/f/TmnkZC/Esb03MinzSiXQ==
   dependencies:
     "@types/node" "*"
     "@types/source-list-map" "*"
-    source-map "^0.6.1"
+    source-map "^0.7.3"
 
 "@types/webpack@^4.41.2":
-  version "4.41.13"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.13.tgz#988d114c8913d039b8a0e0502a7fe4f1f84f3d5e"
-  integrity sha512-RYmIHOWSxnTTa765N6jJBVE45pd2SYNblEYshVDduLw6RhocazNmRzE5/ytvBD8IkDMH6DI+bcrqxh8NILimBA==
+  version "4.41.17"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.17.tgz#0a69005e644d657c85b7d6ec1c826a71bebd1c93"
+  integrity sha512-6FfeCidTSHozwKI67gIVQQ5Mp0g4X96c2IXxX75hYEQJwST/i6NyZexP//zzMOBb+wG9jJ7oO8fk9yObP2HWAw==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -1767,10 +1956,22 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
 "@types/yargs@^11.1.0":
   version "11.1.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-11.1.5.tgz#8d71dfe4848ac5d714b75eca3df9cac75a4f8dac"
   integrity sha512-1jmXgoIyzxQSm33lYgEXvegtkhloHbed2I0QGlTN66U2F9/ExqJWSCSmaWC0IB/g1tW+IYSp+tDhcZBYB1ZGog==
+
+"@types/yargs@^15.0.5":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1992,7 +2193,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.3, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.5.3, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -2011,6 +2212,13 @@ anser@^1.4.7:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.9.tgz#1f85423a5dcf8da4631a341665ff675b96845760"
   integrity sha512-AI+BjTeGt2+WFk4eWcqbQ7snZpDBt8SaLlj0RT2h5xfdWaiy51OjYvqwMrNzJLGy8iOAL6nKDITWO+rd4MkYEA==
+
+ansi-align@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
+  integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
+  dependencies:
+    string-width "^3.0.0"
 
 ansi-colors@3.2.3:
   version "3.2.3"
@@ -2099,6 +2307,39 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+app-builder-bin@3.5.9:
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.9.tgz#a3ac0c25286bac68357321cb2eaf7128b0bc0a4f"
+  integrity sha512-NSjtqZ3x2kYiDp3Qezsgukx/AUzKPr3Xgf9by4cYt05ILWGAptepeeu0Uv+7MO+41o6ujhLixTou8979JGg2Kg==
+
+app-builder-lib@22.7.0:
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.7.0.tgz#ccd3e7ece2d46bc209423a77aa142f74aaf65db0"
+  integrity sha512-blRKwV8h0ztualXS50ciCTo39tbuDGNS+ldcy8+KLvKXuT6OpYnSJ7M6MSfPT+xWatshMHJV1rJx3Tl+k/Sn/g==
+  dependencies:
+    "7zip-bin" "~5.0.3"
+    "@develar/schema-utils" "~2.6.5"
+    async-exit-hook "^2.0.1"
+    bluebird-lst "^1.0.9"
+    builder-util "22.7.0"
+    builder-util-runtime "8.7.1"
+    chromium-pickle-js "^0.2.0"
+    debug "^4.2.0"
+    ejs "^3.1.3"
+    electron-publish "22.7.0"
+    fs-extra "^9.0.0"
+    hosted-git-info "^3.0.4"
+    is-ci "^2.0.0"
+    isbinaryfile "^4.0.6"
+    js-yaml "^3.14.0"
+    lazy-val "^1.0.4"
+    minimatch "^3.0.4"
+    normalize-package-data "^2.5.0"
+    read-config-file "6.0.0"
+    sanitize-filename "^1.6.3"
+    semver "^7.3.2"
+    temp-file "^3.3.7"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -2273,10 +2514,20 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-exit-hook@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
+  integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
+
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async@0.9.x:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
 async@^1.5.0, async@^1.5.2:
   version "1.5.2"
@@ -2295,6 +2546,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -2311,6 +2567,11 @@ autoprefixer@^6.3.1:
     num2fraction "^1.2.2"
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
+
+autosize@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3055,6 +3316,15 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bent@^7.1.0:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/bent/-/bent-7.3.2.tgz#4e4b3f71e44e4eb3409b811f51a2cd5ae59818ef"
+  integrity sha512-iI9r7tiiaWX8tToVBskcfU7omPb3Z1GoLhPZ1gqJD/K8jtHlPNB9dsD2RqiLc4xYOawsCzP8psnSuILN3PK9dg==
+  dependencies:
+    bytesish "^0.4.1"
+    caseless "~0.12.0"
+    is-stream "^2.0.0"
+
 big-integer@^1.6.17:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
@@ -3120,6 +3390,13 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird-lst@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/bluebird-lst/-/bluebird-lst-1.0.9.tgz#a64a0e4365658b9ab5fe875eb9dfb694189bb41c"
+  integrity sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==
+  dependencies:
+    bluebird "^3.5.5"
+
 bluebird@^3.5.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -3155,6 +3432,20 @@ body-parser@1.19.0, body-parser@^1.17.2, body-parser@^1.18.3:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+boxen@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
+  integrity sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    cli-boxes "^2.2.0"
+    string-width "^4.1.0"
+    term-size "^2.1.0"
+    type-fest "^0.8.1"
+    widest-line "^3.1.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3332,10 +3623,46 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.2.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
+
+builder-util-runtime@8.7.1:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.1.tgz#23c808cddd650d4376a7a1518ec1e80e85c10f00"
+  integrity sha512-uEBH1nAnTvzjcsrh2XI3qOzJ39h0+9kuIuwj+kCc3a07TZNGShfJcai8fFzL3mNgGjEFxoq+XMssR11r+FOFSg==
+  dependencies:
+    debug "^4.2.0"
+    sax "^1.2.4"
+
+builder-util@22.7.0:
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.7.0.tgz#0776a66e6d6e408a78bed7f17a7ad22516d9e7f0"
+  integrity sha512-UV3MKL0mwjMq2y9JlBf28Cegpj0CrIXcjGkO0TXn+QZ6Yy9rY6lHOuUvpQ19ct2Qh1o+QSwH3Q1nKUf5viJBBg==
+  dependencies:
+    "7zip-bin" "~5.0.3"
+    "@types/debug" "^4.1.5"
+    "@types/fs-extra" "^9.0.1"
+    app-builder-bin "3.5.9"
+    bluebird-lst "^1.0.9"
+    builder-util-runtime "8.7.1"
+    chalk "^4.0.0"
+    debug "^4.2.0"
+    fs-extra "^9.0.0"
+    is-ci "^2.0.0"
+    js-yaml "^3.14.0"
+    source-map-support "^0.5.19"
+    stat-mode "^1.0.0"
+    temp-file "^3.3.7"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
@@ -3356,6 +3683,11 @@ bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
+bytesish@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/bytesish/-/bytesish-0.4.1.tgz#5fe19b076037ffdfb63e083a53495b1d1c063f6f"
+  integrity sha512-j3l5QmnAbpOfcN/Z2Jcv4poQYfefs8rDdcbc6iEKm+OolvUXAE2APodpWj+DOzqX6Bl5Ys1cQkcIV2/doGvQxg==
 
 cacache@^10.0.4:
   version "10.0.4"
@@ -3445,6 +3777,19 @@ cacheable-request@^2.1.1:
     normalize-url "2.0.1"
     responselike "1.0.2"
 
+cacheable-request@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^3.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^1.0.2"
+
 call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
@@ -3477,7 +3822,7 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.0.0:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -3493,14 +3838,14 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30001068"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001068.tgz#79fa671a063f03485c663f4165252f039c312c36"
-  integrity sha512-FF4o1nUDSnYY8rPCldTJ1486rqcgSZasQtWIMvSC3WOllFJNvmwhuBcApuWC1CD2TKTRnIBXqM4d4lJsCdRJzQ==
+  version "1.0.30001079"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001079.tgz#b12d77d8d09fc82a6eda726c93a6eb09b5c440e1"
+  integrity sha512-FDEnaPlS5YwjUaieK8lzcLFjvv4w6dpvuZvG56XZoxwlEkRpTkVVe+tiU2Rsl4iqpf/K0hae38w7G2jwMz8Thg==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001066"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001066.tgz#0a8a58a10108f2b9bf38e7b65c237b12fd9c5f04"
-  integrity sha512-Gfj/WAastBtfxLws0RCh2sDbTK/8rJuSeZMecrSkNGYxPcv7EzblmDGfWQCFEQcSqYE2BRgQiJh8HOD07N5hIw==
+  version "1.0.30001079"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001079.tgz#ed3e5225cd9a6850984fdd88bf24ce45d69b9c22"
+  integrity sha512-2KaYheg0iOY+CMmDuAB3DHehrXhhb4OZU4KBVGDr/YKyYAcpudaiUQ9PJ9rxrPlKEoJ3ATasQ5AN48MqpwS43Q==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -3555,6 +3900,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -3677,10 +4030,20 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
+chromium-pickle-js@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
+  integrity sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=
+
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -3716,6 +4079,11 @@ classnames@2.x, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+cli-boxes@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
+  integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -3818,24 +4186,19 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clone-response@1.0.2:
+clone-response@1.0.2, clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
 
-clone-stats@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
-  integrity sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=
-
 clone-stats@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
   integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
 
-clone@^1.0.0, clone@^1.0.2:
+clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
@@ -3855,9 +4218,9 @@ cloneable-readable@^1.0.0:
     readable-stream "^2.3.5"
 
 clsx@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
-  integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
 cmd-shim@^2.0.2:
   version "2.1.0"
@@ -3978,6 +4341,13 @@ commander@^2.12.1, commander@^2.20.0, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@~2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3995,6 +4365,11 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+computed-style@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/computed-style/-/computed-style-0.1.4.tgz#7f344fd8584b2e425bedca4a1afc0e300bb05d74"
+  integrity sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -4021,6 +4396,28 @@ conf@^2.0.0:
     make-dir "^1.0.0"
     pkg-up "^2.0.0"
     write-file-atomic "^2.3.0"
+
+configstore@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
+  integrity sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
+  dependencies:
+    dot-prop "^5.2.0"
+    graceful-fs "^4.1.2"
+    make-dir "^3.0.0"
+    unique-string "^2.0.0"
+    write-file-atomic "^3.0.0"
+    xdg-basedir "^4.0.0"
+
+connect@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
+  integrity sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.2"
+    parseurl "~1.3.3"
+    utils-merge "1.0.1"
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -4387,6 +4784,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -4569,6 +4971,13 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 debug@~0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
@@ -4598,6 +5007,59 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
+
+decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
+  integrity sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==
+  dependencies:
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+    tar-stream "^1.5.2"
+
+decompress-tarbz2@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
+  integrity sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^6.1.0"
+    is-stream "^1.1.0"
+    seek-bzip "^1.0.5"
+    unbzip2-stream "^1.0.9"
+
+decompress-targz@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
+  integrity sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==
+  dependencies:
+    decompress-tar "^4.1.1"
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+
+decompress-unzip@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
+  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
+  dependencies:
+    file-type "^3.8.0"
+    get-stream "^2.2.0"
+    pify "^2.3.0"
+    yauzl "^2.4.2"
+
+decompress@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
+  integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -4632,6 +5094,11 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^1.0.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
+  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -4717,7 +5184,7 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-diff@3.5.0, diff@^3.5.0:
+diff@3.5.0, diff@^3.4.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -4751,6 +5218,18 @@ dir-glob@^2.0.0, dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+dmg-builder@22.7.0:
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.7.0.tgz#ead7e7c046cbdc52d29d302a4455f6668cdf7d45"
+  integrity sha512-5Ea2YEz6zSNbyGzZD+O9/MzmaXb6oa15cSKWo4JQ1xP4rorOpte7IOj2jcwYjtc+Los2gu1lvT314OC1OZIWgg==
+  dependencies:
+    app-builder-lib "22.7.0"
+    builder-util "22.7.0"
+    fs-extra "^9.0.0"
+    iconv-lite "^0.5.1"
+    js-yaml "^3.14.0"
+    sanitize-filename "^1.6.3"
+
 dom-helpers@^5.0.0:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
@@ -4759,10 +5238,39 @@ dom-helpers@^5.0.0:
     "@babel/runtime" "^7.8.7"
     csstype "^2.6.7"
 
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
+domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
+domutils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
+  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -4777,6 +5285,23 @@ dot-prop@^4.1.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
+
+dot-prop@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
+  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
+  dependencies:
+    is-obj "^2.0.0"
+
+dotenv-expand@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 download-stats@^0.3.4:
   version "0.3.4"
@@ -4810,7 +5335,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
@@ -4856,6 +5381,33 @@ ejs@^2.5.9, ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
+ejs@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.3.tgz#514d967a8894084d18d3d47bd169a1c0560f093d"
+  integrity sha512-wmtrUGyfSC23GC/B1SMv2ogAUgbQEtDmTIhfqielrG5ExIM9TP4UoYdi90jLF1aTcsWCJNEO0UrgKzP0y3nTSg==
+  dependencies:
+    jake "^10.6.1"
+
+electron-builder@^22.3.2:
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.7.0.tgz#a42d08a1654ffc2f7d9e2860829d3cc55d4a0c81"
+  integrity sha512-t6E3oMutpST64YWbZCg7HodEwJOsnjUF1vnDIHm2MW6CFZPX8tlCK6efqaV66LU0E0Nkp/JH6TE5bCqQ1+VdPQ==
+  dependencies:
+    "@types/yargs" "^15.0.5"
+    app-builder-lib "22.7.0"
+    bluebird-lst "^1.0.9"
+    builder-util "22.7.0"
+    builder-util-runtime "8.7.1"
+    chalk "^4.0.0"
+    dmg-builder "22.7.0"
+    fs-extra "^9.0.0"
+    is-ci "^2.0.0"
+    lazy-val "^1.0.4"
+    read-config-file "6.0.0"
+    sanitize-filename "^1.6.3"
+    update-notifier "^4.1.0"
+    yargs "^15.3.1"
+
 electron-download@^4.1.0, electron-download@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-4.1.1.tgz#02e69556705cc456e520f9e035556ed5a015ebe8"
@@ -4870,6 +5422,20 @@ electron-download@^4.1.0, electron-download@^4.1.1:
     rc "^1.2.1"
     semver "^5.4.1"
     sumchecker "^2.0.2"
+
+electron-publish@22.7.0:
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.7.0.tgz#d92ba7c4007c9ac1dd070593e48028184fb2dc19"
+  integrity sha512-hmU69xlb6vvAV3QfpHYDlkdZMFdBAgDbptoxbLFrnTq5bOkcL8AaDbvxeoZ4+lvqgs29NwqGpkHo2oN+p/hCfg==
+  dependencies:
+    "@types/fs-extra" "^9.0.1"
+    bluebird-lst "^1.0.9"
+    builder-util "22.7.0"
+    builder-util-runtime "8.7.1"
+    chalk "^4.0.0"
+    fs-extra "^9.0.0"
+    lazy-val "^1.0.4"
+    mime "^2.4.5"
 
 electron-rebuild@^1.8.6:
   version "1.11.0"
@@ -4894,9 +5460,9 @@ electron-store@^2.0.0:
     conf "^2.0.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.413:
-  version "1.3.453"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.453.tgz#758a8565a64b7889b27132a51d2abb8b135c9d01"
-  integrity sha512-IQbCfjJR0NDDn/+vojTlq7fPSREcALtF8M1n01gw7nQghCtfFYrJ2dfhsp8APr8bANoFC8vRTFVXMOGpT0eetw==
+  version "1.3.465"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz#d692e5c383317570c2bd82092a24a0308c6ccf29"
+  integrity sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ==
 
 electron@^4.2.11:
   version "4.2.12"
@@ -4965,6 +5531,11 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 entities@~1.1.1:
   version "1.1.2"
@@ -5038,7 +5609,12 @@ es6-promise@^4.2.4:
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
-escape-html@~1.0.3:
+escape-goat@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
+  integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
+
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -5097,6 +5673,19 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
 
 eventemitter3@^2.0.0:
   version "2.0.3"
@@ -5372,9 +5961,9 @@ extsprintf@^1.2.0:
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
@@ -5450,10 +6039,32 @@ file-loader@^1.1.11:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
 
+file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
+  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+
+file-type@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
+  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
+
+file-type@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
+  integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+filelist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"
+  integrity sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -5464,6 +6075,15 @@ filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
   integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.1.0.tgz#54d110810ae74eebfe115c1b995bd07e03cf2184"
+  integrity sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
 
 fill-range@^2.1.0:
   version "2.2.4"
@@ -5493,7 +6113,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-finalhandler@~1.1.2:
+finalhandler@1.1.2, finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
   integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
@@ -5590,9 +6210,9 @@ flatten@^1.0.2:
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 flow-parser@^0.*:
-  version "0.125.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.125.1.tgz#8e6174c0ad8bce8c4e8dbe3c2cfe30235eb0d080"
-  integrity sha512-vrnK98a85yyaPqcZTQmHlrzb4PAiF/WgkI8xZCmyn5sT6/bAKAFbUB+VQqfzTpnvq2VwZ5SThi/xuz3zMLTFRw==
+  version "0.126.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.126.1.tgz#963f569079e015e15475c2fcb106e49c1555a44d"
+  integrity sha512-HDQAPl2F8vuGgyVm/Zx4vmT9Ja/ACAVIWVA3FRIcNoklkWsWDv+2vv2oVLk/2n+jAzESmvA5nFc2ElayVFZN1A==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -5692,6 +6312,11 @@ from2@^2.1.0, from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
@@ -5725,6 +6350,16 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -5849,14 +6484,14 @@ get-stream@^2.2.0:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
-get-stream@^4.0.0:
+get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
 
-get-stream@^5.0.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
@@ -6022,6 +6657,13 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
+  integrity sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==
+  dependencies:
+    ini "^1.3.5"
+
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -6162,10 +6804,32 @@ got@^8.2.0:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+got@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+  dependencies:
+    "@sindresorhus/is" "^0.14.0"
+    "@szmarczak/http-timer" "^1.1.2"
+    cacheable-request "^6.0.0"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^4.1.0"
+    lowercase-keys "^1.0.1"
+    mimic-response "^1.0.1"
+    p-cancelable "^1.0.0"
+    to-readable-stream "^1.0.0"
+    url-parse-lax "^3.0.0"
+
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 grouped-queue@^1.1.0:
   version "1.1.0"
@@ -6284,6 +6948,11 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has-yarn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
+  integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
+
 has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
@@ -6342,15 +7011,37 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+hosted-git-info@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.4.tgz#be4973eb1fd2737b11c9c7c19380739bb249f60d"
+  integrity sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==
+  dependencies:
+    lru-cache "^5.1.1"
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
   integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
 
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
+
 http-cache-semantics@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
+http-cache-semantics@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
+  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
 http-errors@1.7.2:
   version "1.7.2"
@@ -6433,6 +7124,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.2.tgz#af6d628dccfb463b7364d97f715e4b74b8c8c2b8"
+  integrity sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -6479,6 +7177,11 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
+
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -6530,7 +7233,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6594,9 +7297,9 @@ inquirer@^7.1.0:
     through "^2.3.6"
 
 interpret@^1.0.0, interpret@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
-  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -6682,9 +7385,9 @@ is-buffer@^2.0.2, is-buffer@~2.0.3:
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -6692,6 +7395,13 @@ is-ci@^1.0.10:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -6812,6 +7522,24 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
+  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+  dependencies:
+    global-dirs "^2.0.1"
+    is-path-inside "^3.0.1"
+
+is-natural-number@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
+  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
+
+is-npm@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
+  integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -6841,6 +7569,11 @@ is-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
 is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
@@ -6852,6 +7585,11 @@ is-observable@^0.2.0:
   integrity sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=
   dependencies:
     symbol-observable "^0.2.2"
+
+is-path-inside@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -6886,11 +7624,11 @@ is-redirect@^1.0.0:
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
 is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
+  integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   dependencies:
-    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.2.0"
@@ -6940,12 +7678,12 @@ is-text-path@^1.0.0:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-utf8@^0.2.0:
+is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
@@ -6959,6 +7697,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-yarn-global@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
+  integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -6977,7 +7720,7 @@ isbinaryfile@^3.0.2:
   dependencies:
     buffer-alloc "^1.2.0"
 
-isbinaryfile@^4.0.0:
+isbinaryfile@^4.0.0, isbinaryfile@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.6.tgz#edcb62b224e2b4710830b67498c8e4e5a4d2610b"
   integrity sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==
@@ -7026,6 +7769,16 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+jake@^10.6.1:
+  version "10.8.1"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.1.tgz#0f6f5ef13ebe014104527fb4b1b24f44cd1f04d6"
+  integrity sha512-eSp5h9S7UFzKdQERTyF+KuPLjDZa1Tbw8gCVUn98n4PbIkLEDGe4zl7vF4Qge9kQj06HcymnksPk8jznPZeKsA==
+  dependencies:
+    async "0.9.x"
+    chalk "^2.4.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
+
 jquery@x.*:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
@@ -7054,7 +7807,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -7200,6 +7953,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -7234,6 +7996,13 @@ keyv@3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
+keyv@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -7265,12 +8034,24 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+latest-version@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
+  integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
+  dependencies:
+    package-json "^6.3.0"
+
 lazy-cache@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
   integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
   dependencies:
     set-getter "^0.1.0"
+
+lazy-val@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.4.tgz#882636a7245c2cfe6e0a4e3ba6c5d68a137e5c65"
+  integrity sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q==
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -7337,9 +8118,9 @@ less-loader@~2.2.3:
     loader-utils "^0.2.5"
 
 less@^3.0.3:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/less/-/less-3.11.1.tgz#c6bf08e39e02404fe6b307a3dfffafdc55bd36e2"
-  integrity sha512-tlWX341RECuTOvoDIvtFqXsKj072hm3+9ymRBe76/mD6O5ZZecnlAOVDlWAleF2+aohFrxNidXhv2773f6kY7g==
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.11.3.tgz#2d853954fcfe0169a8af869620bcaa16563dcc1c"
+  integrity sha512-VkZiTDdtNEzXA3LgjQiC3D7/ejleBPFVvq+aRI9mIj+Zhmif5TvFPM244bT4rzkvOCvJ9q4zAztok1M7Nygagw==
   dependencies:
     clone "^2.1.2"
     tslib "^1.10.0"
@@ -7347,8 +8128,8 @@ less@^3.0.3:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
     image-size "~0.5.0"
+    make-dir "^2.1.0"
     mime "^1.4.1"
-    mkdirp "^0.5.0"
     promise "^7.1.1"
     request "^2.83.0"
     source-map "~0.6.0"
@@ -7364,6 +8145,13 @@ levenary@^1.1.1:
   integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   dependencies:
     leven "^3.1.0"
+
+line-height@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/line-height/-/line-height-0.3.1.tgz#4b1205edde182872a5efa3c8f620b3187a9c54c9"
+  integrity sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=
+  dependencies:
+    computed-style "~0.1.3"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -7537,6 +8325,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7631,10 +8424,15 @@ lowercase-keys@1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
   integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
 
-lowercase-keys@^1.0.0:
+lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.5"
@@ -7651,6 +8449,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+macaddress@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.9.tgz#3579b8b9acd5b96b4553abf0f394185a86813cb3"
+  integrity sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==
+
 make-dir@^1.0.0, make-dir@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -7658,7 +8461,7 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   dependencies:
     pify "^3.0.0"
 
-make-dir@^2.0.0:
+make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
@@ -7694,6 +8497,11 @@ map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -7777,13 +8585,13 @@ mem-fs-editor@^6.0.0:
     vinyl "^2.2.0"
 
 mem-fs@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/mem-fs/-/mem-fs-1.1.3.tgz#b8ae8d2e3fcb6f5d3f9165c12d4551a065d989cc"
-  integrity sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mem-fs/-/mem-fs-1.2.0.tgz#5f29b2d02a5875cd14cd836c388385892d556cde"
+  integrity sha512-b8g0jWKdl8pM0LqAPdK9i8ERL7nYrzmJfRhxMiWH2uYdfYnb7uXnmwVb0ZGe7xyEl4lj+nLIU3yf4zPUT+XsVQ==
   dependencies:
-    through2 "^2.0.0"
-    vinyl "^1.1.0"
-    vinyl-file "^2.0.0"
+    through2 "^3.0.0"
+    vinyl "^2.0.1"
+    vinyl-file "^3.0.0"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -7859,9 +8667,9 @@ merge-stream@^2.0.0:
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
 merge2@^1.2.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
-  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -7931,7 +8739,7 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3:
+mime@^2.0.3, mime@^2.4.4, mime@^2.4.5:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
@@ -7946,7 +8754,7 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-response@^1.0.0:
+mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
@@ -8154,7 +8962,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -8247,9 +9055,9 @@ nice-try@^1.0.4:
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-abi@^2.11.0, node-abi@^2.2.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.17.0.tgz#f167c92780497ff01eeaf473fcf8138e0fcc87fa"
-  integrity sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
+  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
   dependencies:
     semver "^5.4.1"
 
@@ -8336,9 +9144,9 @@ node-libs-browser@^2.2.1:
     vm-browserify "^1.0.1"
 
 node-releases@^1.1.53:
-  version "1.1.57"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.57.tgz#f6754ce225fad0611e61228df3e09232e017ea19"
-  integrity sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw==
+  version "1.1.58"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.58.tgz#8ee20eef30fa60e52755fcc0942def5a734fe935"
+  integrity sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
 
 nomnom@^1.8.1:
   version "1.8.1"
@@ -8420,6 +9228,11 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
 npm-api@^1.0.0:
   version "1.0.0"
@@ -8689,6 +9502,11 @@ p-cancelable@^0.4.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
   integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
 
+p-cancelable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
+  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
 p-debounce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-2.1.0.tgz#e79f70c6e325cbb9bddbcbec0b81025084671ad3"
@@ -8766,6 +9584,11 @@ p-map@^1.1.1, p-map@^1.2.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
   integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
+p-queue@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.4.2.tgz#03609826682b743be9a22dba25051bd46724fc34"
+  integrity sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==
+
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
@@ -8794,6 +9617,16 @@ p-try@^2.0.0, p-try@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json@^6.3.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
+  integrity sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
+  dependencies:
+    got "^9.6.0"
+    registry-auth-token "^4.0.0"
+    registry-url "^5.0.0"
+    semver "^6.2.0"
 
 paged-request@^2.0.1:
   version "2.0.1"
@@ -8980,10 +9813,17 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  dependencies:
+    through "~2.3"
+
 pbkdf2@^3.0.3:
-  version "3.0.17"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
-  integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
+  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -9369,6 +10209,15 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+postcss@^7.0.27:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 prebuild-install@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-4.0.0.tgz#206ce8106ce5efa4b6cf062fc8a0a7d93c17f3a8"
@@ -9468,7 +10317,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9494,6 +10343,13 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -9564,6 +10420,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pupa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.0.1.tgz#dbdc9ff48ffbea4a26a069b6f9f7abb051008726"
+  integrity sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
+  dependencies:
+    escape-goat "^2.0.0"
 
 puppeteer-to-istanbul@^1.2.2:
   version "1.3.1"
@@ -9647,7 +10510,7 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -9677,7 +10540,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.1.6, rc@^1.2.1:
+rc@^1.1.6, rc@^1.2.1, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -9686,6 +10549,15 @@ rc@^1.1.6, rc@^1.2.1:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-autosize-textarea@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz#4f633e4238de7ba73c1da8fdc307353c50f1c5ab"
+  integrity sha512-rGQLpGUaELvzy3NKzp0kkcppaUtZTptsyR0PGuLotaJDjwRbT0DpD000yCzETpXseJQ/eMsyVGDDHXjXP93u8w==
+  dependencies:
+    autosize "^4.0.2"
+    line-height "^0.3.1"
+    prop-types "^15.5.6"
 
 react-chartjs-2@^2.7.6:
   version "2.9.0"
@@ -9714,9 +10586,9 @@ react-draggable@3.x:
     prop-types "^15.6.0"
 
 react-draggable@^4.0.3:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.2.tgz#f3cefecee25f467f865144cda0d066e5f05f94a0"
-  integrity sha512-zLQs4R4bnBCGnCVTZiD8hPsHtkiJxgMpGDlRESM+EHQo8ysXhKJ2GKdJ8UxxLJdRVceX1j19jy+hQS2wHislPQ==
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
@@ -9811,6 +10683,17 @@ read-cmd-shim@^1.0.1:
   integrity sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==
   dependencies:
     graceful-fs "^4.1.2"
+
+read-config-file@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.0.0.tgz#224b5dca6a5bdc1fb19e63f89f342680efdb9299"
+  integrity sha512-PHjROSdpceKUmqS06wqwP92VrM46PZSTubmNIMJ5DrMwg1OgenSTSEHIkCa6TiOJ+y/J0xnG1fFwG3M+Oi1aNA==
+  dependencies:
+    dotenv "^8.2.0"
+    dotenv-expand "^5.1.0"
+    js-yaml "^3.13.1"
+    json5 "^2.1.2"
+    lazy-val "^1.0.4"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -10034,9 +10917,9 @@ regenerate-unicode-properties@^8.2.0:
     regenerate "^1.4.0"
 
 regenerate@^1.2.1, regenerate@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
-  integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
+  integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -10101,6 +10984,20 @@ regexpu-core@^4.6.0, regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+registry-auth-token@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.1.1.tgz#40a33be1e82539460f94328b0f7f0f84c16d9479"
+  integrity sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==
+  dependencies:
+    rc "^1.2.8"
+
+registry-url@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
+  integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
+  dependencies:
+    rc "^1.2.8"
+
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -10151,11 +11048,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-replace-ext@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
-  integrity sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
 
 replace-ext@^1.0.0:
   version "1.0.1"
@@ -10252,7 +11144,7 @@ resource-loader@^2.2.3:
     mini-signals "^1.1.1"
     parse-uri "^1.0.0"
 
-responselike@1.0.2:
+responselike@1.0.2, responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
@@ -10396,7 +11288,26 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@~1.2.1:
+sanitize-filename@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
+sanitize-html@^1.14.1:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.26.0.tgz#ab38d671526b9b7c08aa7af7f9ad5a73fcc1bbe4"
+  integrity sha512-xriDBT2FbfN0ZKCcX6H6svkh1bZpO2e5ny05RQGZY6vFOMAU13La2L5YYf3XpcjXSksCYXzPj7YPvyGp5wbaUA==
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^4.1.0"
+    lodash "^4.17.15"
+    postcss "^7.0.27"
+    srcset "^2.0.1"
+    xtend "^4.0.1"
+
+sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10427,17 +11338,25 @@ schema-utils@^1.0.0:
     ajv-keywords "^3.1.0"
 
 schema-utils@^2.6.5:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
-  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
   dependencies:
-    ajv "^6.12.0"
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
 scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
   integrity sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=
+
+seek-bzip@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
+  integrity sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=
+  dependencies:
+    commander "~2.8.1"
 
 semantic-ui-css@^2.4.1:
   version "2.4.1"
@@ -10460,6 +11379,13 @@ semantic-ui-react@^0.86.0:
     react-is "^16.7.0"
     shallowequal "^1.1.0"
 
+semver-diff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
+  integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
+  dependencies:
+    semver "^6.3.0"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -10470,12 +11396,12 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.3, semver@^7.2.1:
+semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -10509,12 +11435,14 @@ serialize-javascript@^1.4.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+serialize-javascript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
+  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
+  dependencies:
+    randombytes "^2.1.0"
 
-serve-static@1.14.1:
+serve-static@1.14.1, serve-static@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
   integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
@@ -10624,6 +11552,13 @@ shelljs@^0.8.0, shelljs@^0.8.3:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+showdown@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.1.tgz#134e148e75cd4623e09c21b0511977d79b5ad0ef"
+  integrity sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==
+  dependencies:
+    yargs "^14.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -10751,7 +11686,7 @@ source-map-support@^0.4.15, source-map-support@^0.4.18:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@~0.5.12:
+source-map-support@^0.5.19, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -10773,6 +11708,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spawn-rx@^3.0.0:
   version "3.0.0"
@@ -10828,6 +11768,13 @@ split2@^2.0.0:
   dependencies:
     through2 "^2.0.2"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -10839,6 +11786,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+srcset@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-2.0.1.tgz#8f842d357487eb797f413d9c309de7a5149df5ac"
+  integrity sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -10869,6 +11821,11 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+stat-mode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
+  integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -10889,6 +11846,13 @@ stream-browserify@^2.0.1:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -10962,7 +11926,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -11057,6 +12021,13 @@ strip-ansi@~0.1.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
   integrity sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=
 
+strip-bom-buf@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz#1cb45aaf57530f4caf86c7f75179d2c9a51dd572"
+  integrity sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=
+  dependencies:
+    is-utf8 "^0.2.1"
+
 strip-bom-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz#f87db5ef2613f6968aa545abfe1ec728b6a829ca"
@@ -11076,6 +12047,13 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-dirs@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
+  integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
+  dependencies:
+    is-natural-number "^4.0.1"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -11103,6 +12081,13 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strip-outer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 strong-log-transformer@^1.0.6:
   version "1.0.6"
@@ -11163,6 +12148,13 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
@@ -11208,7 +12200,7 @@ tar-fs@^1.13.0, tar-fs@^1.16.2:
     pump "^1.0.0"
     tar-stream "^1.1.2"
 
-tar-stream@^1.1.2:
+tar-stream@^1.1.2, tar-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
   integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
@@ -11248,6 +12240,14 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
+temp-file@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.3.7.tgz#686885d635f872748e384e871855958470aeb18a"
+  integrity sha512-9tBJKt7GZAQt/Rg0QzVWA8Am8c1EFl+CAv04/aBVqlx5oyfQ508sFIABshQ0xbZu6mBrFLWIUXO/bbLYghW70g==
+  dependencies:
+    async-exit-hook "^2.0.1"
+    fs-extra "^8.1.0"
+
 temp-write@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
@@ -11275,16 +12275,21 @@ tempfile@^1.1.1:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
+term-size@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
+  integrity sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
+
 terser-webpack-plugin@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
-  integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz#2c63544347324baafa9a56baaddf1634c8abfc2f"
+  integrity sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==
   dependencies:
     cacache "^12.0.2"
     find-cache-dir "^2.1.0"
     is-wsl "^1.1.0"
     schema-utils "^1.0.0"
-    serialize-javascript "^2.1.2"
+    serialize-javascript "^3.1.0"
     source-map "^0.6.1"
     terser "^4.1.2"
     webpack-sources "^1.4.0"
@@ -11327,7 +12332,7 @@ through2@^2.0.0, through2@^2.0.2:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through2@^3.0.1:
+through2@^3.0.0, through2@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
@@ -11342,7 +12347,7 @@ through2@~0.2.3:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -11403,6 +12408,11 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
+
+to-readable-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
+  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -11484,10 +12494,24 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
 
 ts-md5@^1.2.2:
   version "1.2.7"
@@ -11564,6 +12588,11 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -11572,15 +12601,22 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@latest:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -11602,6 +12638,14 @@ umd-compat-loader@^2.1.1:
     ast-types "^0.9.2"
     loader-utils "^1.0.3"
     recast "^0.11.17"
+
+unbzip2-stream@^1.0.9:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 underscore@~1.6.0:
   version "1.6.0"
@@ -11665,10 +12709,22 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -11720,6 +12776,25 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-notifier@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz#4866b98c3bc5b5473c020b1250583628f9a328f3"
+  integrity sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==
+  dependencies:
+    boxen "^4.2.0"
+    chalk "^3.0.0"
+    configstore "^5.0.1"
+    has-yarn "^2.1.0"
+    import-lazy "^2.1.0"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.3.1"
+    is-npm "^4.0.0"
+    is-yarn-global "^0.3.0"
+    latest-version "^5.0.0"
+    pupa "^2.0.1"
+    semver-diff "^3.1.1"
+    xdg-basedir "^4.0.0"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -11780,6 +12855,11 @@ user-home@^2.0.0:
   integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
   dependencies:
     os-homedir "^1.0.0"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -11864,26 +12944,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vinyl-file@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/vinyl-file/-/vinyl-file-2.0.0.tgz#a7ebf5ffbefda1b7d18d140fcb07b223efb6751a"
-  integrity sha1-p+v1/779obfRjRQPyweyI++2dRo=
+vhost@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vhost/-/vhost-3.0.2.tgz#2fb1decd4c466aa88b0f9341af33dc1aff2478d5"
+  integrity sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=
+
+vinyl-file@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vinyl-file/-/vinyl-file-3.0.0.tgz#b104d9e4409ffa325faadd520642d0a3b488b365"
+  integrity sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=
   dependencies:
     graceful-fs "^4.1.2"
     pify "^2.3.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
+    strip-bom-buf "^1.0.0"
     strip-bom-stream "^2.0.0"
-    vinyl "^1.1.0"
-
-vinyl@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
-  integrity sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=
-  dependencies:
-    clone "^1.0.0"
-    clone-stats "^0.0.1"
-    replace-ext "0.0.1"
+    vinyl "^2.0.1"
 
 vinyl@^2.0.1, vinyl@^2.2.0:
   version "2.2.0"
@@ -11903,9 +12978,9 @@ vm-browserify@^1.0.1:
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 vscode-debugprotocol@^1.32.0:
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.40.0.tgz#63e1f670a6f5c4928f3f91b27b259a21c4db7861"
-  integrity sha512-Fwze+9qbLDPuQUhtITJSu/Vk6zIuakNM1iR2ZiZRgRaMEgBpMs2JSKaT0chrhJHCOy6/UbpsUbUBIseF6msV+g==
+  version "1.41.0"
+  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.41.0.tgz#fc99b01dee26e9f25cbb5708318fc0081002808c"
+  integrity sha512-Sxp7kDDuhpEZiDaIfhM0jLF3RtMqvc6CpoESANE77t351uezsd/oDoqALLcOnmmsDzTgQ3W0sCvM4gErnjDFpA==
 
 vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
@@ -11932,6 +13007,11 @@ vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+
+vscode-ripgrep@^1.2.4:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.6.1.tgz#09519917f1211d9c905af1788383f9bc5f52ede9"
+  integrity sha512-ad9kgxyFWmjPGRiQTAtQ2/4qW4d7aCYAKeieafFxLPCOxEXE9dBT4pGHZassldvXQYBWZXO57NiwiRWFhIY8Ew==
 
 vscode-textmate@^4.0.1:
   version "4.4.0"
@@ -12100,6 +13180,13 @@ wide-align@1.1.3, wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+widest-line@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
+  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+  dependencies:
+    string-width "^4.0.0"
+
 with-open-file@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/with-open-file/-/with-open-file-0.1.7.tgz#e2de8d974e8a8ae6e58886be4fe8e7465b58a729"
@@ -12178,6 +13265,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 write-json-file@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
@@ -12217,6 +13314,11 @@ xdg-basedir@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
+xdg-basedir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
 xdg-trashdir@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/xdg-trashdir/-/xdg-trashdir-2.1.1.tgz#59a60aaf8e6f9240c1daed9a0944b2f514c27d8e"
@@ -12228,7 +13330,7 @@ xdg-trashdir@^2.1.1:
     user-home "^2.0.0"
     xdg-basedir "^2.0.0"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
@@ -12356,7 +13458,7 @@ yargs@^11.0.0, yargs@^11.1.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^14.2.0:
+yargs@^14.2, yargs@^14.2.0:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
   integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
@@ -12409,7 +13511,7 @@ yargs@^8.0.2:
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
 
-yauzl@^2.10.0:
+yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
@@ -12418,9 +13520,9 @@ yauzl@^2.10.0:
     fd-slicer "~1.1.0"
 
 yeoman-environment@^2.0.0, yeoman-environment@^2.0.5, yeoman-environment@^2.9.5:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.10.2.tgz#cfd1ffd28787b2058dde449fb8b31c290fab3158"
-  integrity sha512-7HuUixYvGO1lVPjOZ0HOweL+WXuX7COEO0V5/R+K6Rsyy+hcl+PHMOcsUQMgq5BAGfRJo9CTt4EkE6iqH+SoQA==
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.10.3.tgz#9d8f42b77317414434cc0e51fb006a4bdd54688e"
+  integrity sha512-pLIhhU9z/G+kjOXmJ2bPFm3nejfbH+f1fjYRSOteEXDBrv1EoJE/e+kuHixSXfCYfTkxjYsvRaDX+1QykLCnpQ==
   dependencies:
     chalk "^2.4.1"
     debug "^3.1.0"


### PR DESCRIPTION
Added the open-vsx registry integration in the example app. One can browse and install
VS Code extensions from the extensions' view. As well added a set of VS Code Built-ins
to support syntax highlighting and more for multiple languages, like VS Code does OOTB.
    
Added vscode extensions vscode-clangd and cdt-gdb-vscode (Electron only - the browser
version uses @theia/cpp-debug which does not work well ATM in electron-builder
packagings).
    
Added an electron-builder config for Linux, which generates an .Appimage and a Debian
package.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>
