### PR TITLE
trace-explorer: add to default layout

### DIFF
--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -1,7 +1,9 @@
 import { AbstractViewContribution } from "@theia/core/lib/browser/shell/view-contribution";
 import { TraceExplorerWidget, TRACE_EXPLORER_ID, TRACE_EXPLORER_LABEL } from "./trace-explorer-widget";
+import { FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser";
 
-export class TraceExplorerContribution extends AbstractViewContribution<TraceExplorerWidget> {
+export class TraceExplorerContribution extends AbstractViewContribution<TraceExplorerWidget> implements FrontendApplicationContribution {
+
     constructor() {
         super({
             widgetId: TRACE_EXPLORER_ID,
@@ -12,4 +14,9 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
             toggleCommandId: 'trace-explorer:toggle'
         });
     }
+
+    async initializeLayout(_app: FrontendApplication): Promise<void> {
+        await this.openView({ activate: false });
+    }
+
 }

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -44,7 +44,7 @@ export default new ContainerModule(bind => {
 
     bindViewContribution(bind, TraceExplorerContribution);
     bind(TraceExplorerWidget).toSelf();
-    // bind(FrontendApplicationContribution).toService(TraceExplorerContribution);
+    bind(FrontendApplicationContribution).toService(TraceExplorerContribution);
     bind(WidgetFactory).toDynamicValue(context => ({
         id: TRACE_EXPLORER_ID,
         createWidget: () => context.container.get<TraceExplorerWidget>(TraceExplorerWidget)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #80

The following commit adds the `Trace Explorer` to the **default layout** of the application.
Adding the view to the default layout will make it more discoverable and accessible to end-users, and can later be automatically opened if a trace is identified.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. checkout the branch, build the application and start: `yarn && (cd browser-app && yarn start)`
2. execute the command `Reset Workbench Layout`\
(using the command palette <kbd>ctrlcmd</kbd>+<kbd>shift</kbd>+<kbd>p</kbd>)\
(the command resets the layout to it's default (without local-storage storing the previous layout))
3. when the application is reloaded, the view should be present in the sidebar.

<div align='center'>

![Screenshot from 2020-06-18 10-44-03](https://user-images.githubusercontent.com/40359487/85034966-a8759680-b150-11ea-9014-33adbbfeebb9.png)

</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>