### PR TITLE
Github Actions CI test & lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [10.x]
+
+    steps:
+    - name: install dependencies on ubuntu
+      if: startsWith(matrix.os,'ubuntu')
+      run: |
+        sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev 
+    
+    - uses: actions/checkout@v2
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    
+    - name: Cache node_modules with yarn
+      uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    
+    - run: yarn --frozen-lockfile
+    
+    - run: yarn test
+      env:
+        CI: true
+        
+  code-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10'
+
+    # ESLint and Prettier must be in `package.json`
+    - run: yarn --frozen-lockfile --ignore-scripts
+
+    - run: yarn lint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start:server": "./trace-compass-server/tracecompass-server",
     "start-all:browser": "yarn start:server & yarn start:browser",
     "start-all:electron": "yarn start:server & yarn start:electron",
-    "lint": "yarn workspace trace-viewer run lint"
+    "lint": "yarn workspace trace-viewer run lint",
+    "test": "echo test"
   },
   "devDependencies": {
     "lerna": "2.4.0"


### PR DESCRIPTION
**What it does**

Closes #78 

The following pull-request adds .yml config file for Github Actions CI. The workflow includes running tests on ubuntu, macos, windows with node version 10.x

Code linting is run only on ubuntu with autofix and supports for `eslint` and `prettier` using [samuelmeuli/lint-action@v1](https://github.com/samuelmeuli/lint-action)

The change is part of the: [issues/78: Add a CI for the trace extension](https://github.com/theia-ide/theia-trace-extension/issues/78)

Signed-off-by: Quoc-Hao TRAN \<quoc-hao.tran@polymtl.ca\>