### PR TITLE
update repo for Electron 9 / node 12

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -8,13 +8,12 @@ RUN sudo apt-get update \
     # window manager
     && sudo apt-get install -y jwm \
     # electron
-    && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 \
+    && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 libgbm1 \
     # native-keymap
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Pin Node.js to v10.
-ENV NODE_VERSION="10.21.0"
+ENV NODE_VERSION="12.14.1"
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,7 +21,7 @@ tasks:
     yarn download:sample-traces &&
     yarn
   command: >
-    yarn start:electron ../TraceCompassTutorialTraces/ --hostname=0.0.0.0
+    yarn start:electron ../TraceCompassTutorialTraces/ --hostname=0.0.0.0 --ignore-gpu-blacklist --no-sandbox
 github:
   prebuilds:
     pullRequestsFromForks: true

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -42,7 +42,7 @@
     "download:plugins": "theia download:plugins -p=true"
   },
   "engines": {
-    "node": ">=10.2.0 < 12"
+    "node": ">=10.2.0 < 13"
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -3,7 +3,7 @@
   "name": "electron-theia-trace-example-app",
   "main": "scripts/theia-trace-main.js",
   "build": {
-    "electronVersion": "4.2.12"
+    "electronVersion": "9.1.2"
   },
   "version": "0.0.1",
   "theia": {
@@ -54,7 +54,7 @@
     "download:plugins": "theia download:plugins -p=true"
   },
   "engines": {
-    "node": ">=10.2.0 < 12"
+    "node": ">=10.2.0 < 13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #106
    
A few little tweaks are necessary to accommodate the new Electron and node versions.   ATM the Electron example app fails at runtime when running on Gitpod, because of a missing a dynamic library:
    
`/workspace/theia-trace-extension/node_modules/electron/dist/electron: error while loading shared libraries: libgbm.so.1: cannot`
    
We need to update the `Gitpod` config so the dockerfile used for this repoi will contain a new Ubuntu package, required for Electron 9. This config file originally came from the main Theia repo, and the updated version is the same. See LICENSE.gitpod.md for more details.

Here's where the `--no-sandbox` idea came from - it permits the Electron version of the example app to start in Gitpod:
https://github.com/eclipse-theia/theia/pull/7968#issuecomment-659029745
    
Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>
