### PR TITLE
Allow height resizing of tables and charts.

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/components/abstract-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/abstract-output-component.tsx
@@ -17,11 +17,20 @@ export interface AbstractOutputProps {
     resolution?: number;
     outputDescriptor: OutputDescriptor;
     style: OutputComponentStyle;
+    // WidthProvider (react-grid-layout version 0.16.7) has a bug.
+    // Workaround for it needs width to be explicitly passed
+    // https://github.com/STRML/react-grid-layout/issues/961
+    widthWPBugWorkaround: number;
     onOutputRemove: (outputId: string) => void;
     // TODO Not sure
     unitController: TimeGraphUnitController;
     onSelectionRangeChange?: () => void;
     onViewRangeChange?: () => void;
+    className?: string;
+    onMouseUp?: VoidFunction;
+    onMouseDown?: VoidFunction;
+    onTouchStart?: VoidFunction;
+    onTouchEnd?: VoidFunction;
 }
 
 export interface AbstractOutputState {
@@ -32,7 +41,7 @@ export interface AbstractOutputState {
 export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
 
     private mainAreaContainer: React.RefObject<HTMLDivElement>;
-    private handleWidth = 30;
+    private readonly HANDLE_WIDTH = 30;
 
     constructor(props: P) {
         super(props);
@@ -41,13 +50,23 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     render(): JSX.Element {
         this.closeComponent = this.closeComponent.bind(this);
-        return <div className='output-container' style={{ width: this.props.style.width }}>
-            <div className='widget-handle' style={{ width: this.handleWidth }}>
+        const localStyle = Object.assign({},this.props.style);
+        localStyle.width = this.props.widthWPBugWorkaround;
+        return <div style={localStyle}
+            className={'output-container '+this.props.className}
+            onMouseUp={this.props.onMouseUp}
+            onMouseDown={this.props.onMouseDown}
+            onTouchStart={this.props.onTouchStart}
+            onTouchEnd={this.props.onTouchEnd}
+           >
+            <div className='widget-handle' style={{ width: this.HANDLE_WIDTH, height:this.props.style.height }}>
                 {this.renderTitleBar()}
             </div>
-            <div className='main-output-container' ref={this.mainAreaContainer} style={{ width: this.props.style.width - this.handleWidth }}>
+            <div className='main-output-container' ref={this.mainAreaContainer}
+            style={{ width: this.props.widthWPBugWorkaround - this.HANDLE_WIDTH, height:this.props.style.height }}>
                 {this.renderMainArea()}
             </div>
+            {this.props.children}
         </div>;
     }
 
@@ -75,7 +94,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     }
 
     public getHandleWidth(): number {
-        return this.handleWidth;
+        return this.HANDLE_WIDTH;
     }
 
     abstract renderMainArea(): React.ReactNode;

--- a/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
@@ -6,7 +6,7 @@ import { Entry, EntryHeader } from 'tsp-typescript-client/lib/models/entry';
 
 export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
     renderMainArea(): React.ReactNode {
-        const treeWidth = this.props.style.width - this.props.style.chartWidth - this.getHandleWidth();
+        const treeWidth = this.props.widthWPBugWorkaround - this.getHandleWidth() - this.props.style.chartWidth;
         return <React.Fragment>
             <div ref={this.treeRef} className='output-component-tree'
                 onScroll={_ev => { this.synchronizeTreeScroll(); }}
@@ -14,7 +14,7 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
             >
                 {this.renderTree()}
             </div>
-            <div className='output-component-chart' style={{ width: this.props.style.chartWidth, backgroundColor: '#3f3f3f' }}>
+            <div className='output-component-chart' style={{ width: this.props.style.chartWidth, height: this.props.style.height , backgroundColor: '#3f3f3f' }}>
                 {this.renderChart()}
             </div>
         </React.Fragment>;

--- a/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
@@ -52,7 +52,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     renderMainArea(): React.ReactNode {
-        return <div id='events-table' className='ag-theme-balham-dark' style={{height: this.props.tableHeight, width: this.props.tableWidth}}>
+        return <div id='events-table' className='ag-theme-balham-dark' style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}>
             <AgGridReact
                 columnDefs={this.columnArray}
                 rowModelType='infinite'

--- a/viewer-prototype/src/browser/trace-viewer/components/timegraph-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/timegraph-output-component.tsx
@@ -142,7 +142,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     renderChart(): React.ReactNode {
         return <React.Fragment>
             {this.state.outputStatus === ResponseStatus.COMPLETED ?
-                <div id='timegraph-main' className='ps__child--consume' onWheel={ev => { ev.preventDefault(); ev.stopPropagation(); }} >
+                <div id='timegraph-main' className='ps__child--consume' onWheel={ev => { ev.preventDefault(); ev.stopPropagation(); }} style={{ height:this.props.style.height }} >
                     {this.renderTimeGraphContent()}
                 </div> :
                 'Analysis running...'}
@@ -150,7 +150,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private renderTimeGraphContent() {
-        return <div id='main-timegraph-content' ref={this.horizontalContainer}>
+        return <div id='main-timegraph-content' ref={this.horizontalContainer} style={{height:this.props.style.height}} >
             {this.getChartContainer()}
         </div>;
     }
@@ -164,7 +164,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             options={
                 {
                     id: 'timegraph-chart',
-                    height: this.props.style.height,
+                    height: parseInt(this.props.style.height.toString()),
                     width: this.props.style.chartWidth, // this.props.style.mainWidth,
                     backgroundColor: this.props.style.chartBackgroundColor,
                     classNames: 'horizontal-canvas'
@@ -186,7 +186,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             options={{
                 id: 'vscroll',
                 width: 10,
-                height: this.props.style.height,
+                height: parseInt(this.props.style.height.toString()),
                 backgroundColor: this.props.style.naviBackgroundColor
             }}
             onWidgetResize={this.props.addWidgetResizeHandler}

--- a/viewer-prototype/src/browser/trace-viewer/components/trace-context-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/trace-context-component.tsx
@@ -44,7 +44,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private readonly COMPONENT_WIDTH_PROPORTION: number = 0.85;
     private readonly DEFAULT_COMPONENT_WIDTH: number = 1500;
     private readonly DEFAULT_CHART_WIDTH: number = Math.floor(this.DEFAULT_COMPONENT_WIDTH * this.COMPONENT_WIDTH_PROPORTION);
-    private readonly DEFAULT_COMPONENT_HEIGHT: number = 300;
+    private readonly DEFAULT_COMPONENT_HEIGHT: number = 10;
+    private readonly DEFAULT_COMPONENT_ROWHEIGHT: number = 20;
     private readonly SCROLLBAR_PADDING: number = 12;
 
     private unitController: TimeGraphUnitController;
@@ -76,11 +77,11 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                 width: this.DEFAULT_COMPONENT_WIDTH, // 1245,
                 chartWidth: this.DEFAULT_CHART_WIDTH,
                 height: this.DEFAULT_COMPONENT_HEIGHT,
+                rowHeight: this.DEFAULT_COMPONENT_ROWHEIGHT,
                 naviBackgroundColor: 0x3f3f3f,
                 chartBackgroundColor: 0x3f3f3f,
                 cursorColor: 0x259fd8,
-                lineColor: 0xbbbbbb,
-                rowHeight: 20
+                lineColor: 0xbbbbbb
             }
         };
         const absoluteRange = traceRange.getDuration();
@@ -187,8 +188,12 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
             <div style={{ marginLeft: this.state.style.width - this.state.style.chartWidth }}>
                 <TimeAxisComponent unitController={this.unitController} style={this.state.style} addWidgetResizeHandler={this.addWidgetResizeHandler} />
             </div>
-            <ResponsiveGridLayout className='outputs-grid-layout' margin={[0, 5]} isResizable={false}
-                layouts={{ lg: layouts }} cols={{ lg: 1 }} breakpoints={{ lg: 1200 }} rowHeight={300} draggableHandle={'.widget-handle'}
+            {
+            // Syntax to use ReactGridLayout with Custom Components, while passing resized dimensions to children:
+            // https://github.com/STRML/react-grid-layout/issues/299#issuecomment-524959229
+            }
+            <ResponsiveGridLayout className='outputs-grid-layout' margin={[0, 5]} isResizable={true} isRearrangeable={true} isDraggable={true}
+                layouts={{ lg: layouts }} cols={{ lg: 1 }} breakpoints={{ lg: 1200 }} rowHeight={this.DEFAULT_COMPONENT_ROWHEIGHT} draggableHandle={'.widget-handle'}
                 style={{ paddingRight: this.SCROLLBAR_PADDING }}>
                 {outputs.map(output => {
                     const responseType = output.type;
@@ -201,22 +206,17 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                         selectionRange: this.state.currentTimeSelection,
                         style: this.state.style,
                         onOutputRemove: this.props.onOutputRemove,
-                        unitController: this.unitController
+                        unitController: this.unitController,
+                        widthWPBugWorkaround: this.state.style.width
                     };
                     switch (responseType) {
                         case 'TIME_GRAPH':
-                            return <div key={output.id}>
-                                <TimegraphOutputComponent key={output.id} {...outputProps}
-                                    addWidgetResizeHandler={this.addWidgetResizeHandler} />
-                            </div>;
+                            return <TimegraphOutputComponent key={output.id} {...outputProps}
+                                    addWidgetResizeHandler={this.addWidgetResizeHandler} />;
                         case 'TREE_TIME_XY':
-                            return <div key={output.id}>
-                                <XYOutputComponent key={output.id} {...outputProps} />
-                            </div>;
+                            return <XYOutputComponent key={output.id} {...outputProps} />;
                         case 'TABLE':
-                            return <div key={output.id}>
-                                <TableOutputComponent key={output.id} {...outputProps} />
-                            </div>;
+                            return <TableOutputComponent key={output.id} {...outputProps} />;
                         default:
                             break;
                     }
@@ -244,7 +244,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                     x: 0,
                     y: index,
                     w: 1,
-                    h: 1
+                    h: this.DEFAULT_COMPONENT_HEIGHT
                 };
                 layouts.push(itemLayout);
             });

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/output-component-style.ts
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/output-component-style.ts
@@ -1,7 +1,11 @@
 export interface OutputComponentStyle {
     width: number;
     chartWidth: number;
-    height: number;
+    // react-grid-layout - The library used for resizing components
+    // inserts new React components during compilation, and the dimensions
+    // it returns are strings (pixels).
+    // Currently, the components are only height-resizable.
+    height: number | string;
     naviBackgroundColor: number;
     chartBackgroundColor: number;
     cursorColor: number;

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/timegraph-container-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/timegraph-container-component.tsx
@@ -24,8 +24,19 @@ export class ReactTimeGraphContainer extends React.Component<ReactTimeGraphConta
         });
 
         this.props.onWidgetResize(() => {
-            if (this.container) { this.container.reInitCanvasSize(this.props.options.width); }
+            if (this.container) { this.container.reInitCanvasSize(this.props.options.width, this.props.options.height); }
         });
+    }
+
+    shouldComponentUpdate(nextProps: ReactTimeGraphContainer.Props): boolean {
+        return nextProps.options.height !== this.props.options.height
+               || nextProps.options.width !== this.props.options.width ;
+    }
+
+    componentDidUpdate(prevProps: ReactTimeGraphContainer.Props): void {
+        if (prevProps.options.height !== this.props.options.height && this.container) {
+            this.container.reInitCanvasSize(this.props.options.width, this.props.options.height);
+        }
     }
 
     render(): JSX.Element {

--- a/viewer-prototype/src/browser/trace-viewer/components/xy-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/xy-output-component.tsx
@@ -109,7 +109,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         // width={this.props.style.chartWidth}
         return <React.Fragment>
             {this.state.outputStatus === ResponseStatus.COMPLETED ?
-                <Line data={this.state.XYData} height={this.props.style.height} options={lineOptions} ref={this.lineChartRef}></Line> :
+                <Line data={this.state.XYData} height={parseInt(this.props.style.height.toString())} options={lineOptions} ref={this.lineChartRef}></Line> :
                 'Analysis running...'}
         </React.Fragment>;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,102 @@
     "@pixi/core" "5.3.3"
     "@pixi/display" "5.3.3"
 
+"@pixi/canvas-display@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-display/-/canvas-display-5.3.3.tgz#74c7db0ee49d5096cc2d8c5bd8d7c229e437ed6e"
+  integrity sha512-V481/gCZF/mSEGpXOnAOMor0J27nheSDZ0CIwRIqNn2Dbys6S3OfTlzhAKqN480RQTaHnAZa9Zi4GlblDzjULw==
+  dependencies:
+    "@pixi/display" "5.3.3"
+
+"@pixi/canvas-extract@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-extract/-/canvas-extract-5.3.3.tgz#f10aa68b7bbb2365edbb0fc5f8301b960967adc5"
+  integrity sha512-OAZ25gcMVXDIUqFiIPolIVCJlBCV7T5aedDsG0LDS33RSFq5CQruf6AXqb7HUshSMwmajOrioqOp/tR8KfEZVQ==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/canvas-graphics@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-graphics/-/canvas-graphics-5.3.3.tgz#8e8a3bb56daf7f7a31305bbc37b2a626ab47cb89"
+  integrity sha512-n+NbonZBxpZwujwizg+gK2qc/RCpd+H+st4IhwqQY6lzXrjM0gEJL/St6XZwKtu73yKelsBSVeUZJbupajtzdA==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/graphics" "5.3.3"
+    "@pixi/math" "5.3.3"
+
+"@pixi/canvas-mesh@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-mesh/-/canvas-mesh-5.3.3.tgz#d8e3073de036439c998d98b52d152d0b97abcb39"
+  integrity sha512-HM+U/pEmwaj0W6lPFQelONgZjUVN96Ndp101625AX7/mTUFo5SG0Q7oRLegactTTbvkNOnSBk+E8R61sd7hoiw==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/constants" "5.3.3"
+    "@pixi/mesh" "5.3.3"
+    "@pixi/mesh-extras" "5.3.3"
+    "@pixi/settings" "5.3.3"
+
+"@pixi/canvas-particles@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-particles/-/canvas-particles-5.3.3.tgz#049ef5259c6bac35d4aac8baf74e235d932a3873"
+  integrity sha512-aBXSNeVKHttGDhzs7Qeu03tVh+MJS9gqWSx93sMjTDA26ZUrFz6PtQjUYYBiys0LJHDgjCCu+4iEa17Le9qa9Q==
+  dependencies:
+    "@pixi/particles" "5.3.3"
+
+"@pixi/canvas-prepare@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-prepare/-/canvas-prepare-5.3.3.tgz#a7cbaa94f309b1e6846f5fabe3e1d3aad8abc4a8"
+  integrity sha512-o90MTTZD1I9c1517Nfhg7b0/lwRx3HQgMw2FQkgmN0qYslsvU35f5bFkg99oYRkJ9lFWQB78jRqkzNLkQ2XLSQ==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/prepare" "5.3.3"
+
+"@pixi/canvas-renderer@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-renderer/-/canvas-renderer-5.3.3.tgz#a569dfa46907a41c073ce1f59050cd2ac667b08c"
+  integrity sha512-xAi3x2D0Jykk5vTsTMPEPTazQ7tmHnIj1pbEXL+knmNL0zmpekVpg5nY2RoztHW98oLfno5at5JNWtSQA/tiQA==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/canvas-sprite-tiling@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-sprite-tiling/-/canvas-sprite-tiling-5.3.3.tgz#4a0d463ce7fa780eb390cc09fbd57f99bdc9e91b"
+  integrity sha512-DGUjV8yP7/0NE3kusdhgXYpsDG08AOyDBSOhT0VcIys5D78ldSACzxm3qy3J3axXtQTXR9tDwKBL0FoPeoL4qg==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/canvas-sprite" "5.3.3"
+    "@pixi/sprite-tiling" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/canvas-sprite@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-sprite/-/canvas-sprite-5.3.3.tgz#70e7c5f7e7805c61f8a9a057c3eb4fede1349736"
+  integrity sha512-HpjDHBwRQuyPUQt7rXBsLACfukfFNk70PfEZzR3HN6CW0wjUh02bLTtF3UEmNS2Ou/kI8pAXi5MQX3BtlOBO7g==
+  dependencies:
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/constants" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/canvas-text@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/canvas-text/-/canvas-text-5.3.3.tgz#72aa9589d3540bc32ba9cb91a364720cbd89fee3"
+  integrity sha512-/m5lF+TzxG0rMsSCiHuvv37zVVxmAzKHwl8IybmR6YHfjrWEtvpxuyls7kr/ahFtR2l9hKJvexdmQRYkNy2ITg==
+  dependencies:
+    "@pixi/sprite" "5.3.3"
+    "@pixi/text" "5.3.3"
+
 "@pixi/constants@5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@pixi/constants/-/constants-5.3.3.tgz#faaed2d0ce364d67fe3e69ac97e9db1f6ad6c041"
@@ -8759,7 +8855,7 @@ jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
-keyboard-key@^1.0.4:
+keyboard-key@1.1.0, keyboard-key@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.1.0.tgz#6f2e8e37fa11475bb1f1d65d5174f1b35653f5b7"
   integrity sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ==
@@ -10762,7 +10858,24 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pixi.js@^5.0.0:
+pixi.js-legacy@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/pixi.js-legacy/-/pixi.js-legacy-5.3.3.tgz#bc2efff1c9d7c0adbdd082cfa9d19888d59f3a43"
+  integrity sha512-WQLRDwPHw3tCP5VAaMuY2g02+pi695BB4xSyBsx1/Y8iIGTM/QWPLqcRkw9wAfYAAUPP8tlHjwRQ9BXBWh1DVA==
+  dependencies:
+    "@pixi/canvas-display" "5.3.3"
+    "@pixi/canvas-extract" "5.3.3"
+    "@pixi/canvas-graphics" "5.3.3"
+    "@pixi/canvas-mesh" "5.3.3"
+    "@pixi/canvas-particles" "5.3.3"
+    "@pixi/canvas-prepare" "5.3.3"
+    "@pixi/canvas-renderer" "5.3.3"
+    "@pixi/canvas-sprite" "5.3.3"
+    "@pixi/canvas-sprite-tiling" "5.3.3"
+    "@pixi/canvas-text" "5.3.3"
+    pixi.js "5.3.3"
+
+pixi.js@5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-5.3.3.tgz#6e326a52542f4acd97ea3f8593cb0aeae502df9a"
   integrity sha512-uFQOXXyPMAVVayDebSFBS1AFfPT6QYNuz9Vu11yI2/k1DAef/rbYoJpSMM6SeB6dezDJPtIAaXXNxdaYzbe+kg==
@@ -13346,13 +13459,15 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timeline-chart@next:
-  version "0.1.0-next.35a4f328"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.1.0-next.35a4f328.tgz#124f32db2a639d43eeacd1d73d2f1aa39d480707"
-  integrity sha512-OonG98d+re9SFwhXtOL1L88ENb4gEKDxUqVA5NKWUQkjm+MhySp6lsoubo9WDPGQlvPx7BK75Bz7UyQsSzJL3g==
+  version "0.2.0-next.e3c754b0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0-next.e3c754b0.tgz#49934ed5d2c9d5d2987c996324edee386c9ee419"
+  integrity sha512-zMcDFmeTkc+t1c6rACAgfTaw9LH0ZQOXOGKxXdhxzmmn3muFd4IeIC5I7dCtU+IMJ4nvp3iZ9JHB7j5ZGlxpUQ==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
+    glob "^7.1.6"
+    keyboard-key "1.1.0"
     lodash.throttle "^4.1.1"
-    pixi.js "^5.0.0"
+    pixi.js-legacy "^5.3.3"
     rimraf latest
 
 timers-browserify@^2.0.4:


### PR DESCRIPTION
Commit related technical details:
1. WidthProvider has a bug. (https://github.com/STRML/react-grid-layout/issues/961). Had to work around it.
2. Syntax to use ReactGridLayout with Custom Components, while passing resized dimensions to children. https://github.com/STRML/react-grid-layout/issues/299#issuecomment-524959229
