### PR TITLE
#144: Show 'Not implemented yet!' for unsupported data provider type

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/components/null-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/null-output-component.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } from './abstract-output-component';
+
+type NullOutputState = AbstractOutputState & {
+};
+
+type NullOutputProps = AbstractOutputProps & {
+};
+
+export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps, NullOutputState> {
+    constructor(props: NullOutputProps) {
+        super(props);
+    }
+    renderMainArea(): React.ReactNode {
+        const treeWidth = this.props.widthWPBugWorkaround - this.getHandleWidth() - this.props.style.chartWidth;
+        return <React.Fragment>
+            <div className='output-component-tree'
+                style={{ width: treeWidth, height: this.props.style.height }}
+            >
+                {''}
+            </div>
+            <div className='output-component-chart' style={{ fontSize: 24, width: this.props.style.chartWidth, height: this.props.style.height, backgroundColor: '#3f3f3f', }}>
+                {'Not implemented yet!'}
+            </div>
+        </React.Fragment>;
+    }
+  }

--- a/viewer-prototype/src/browser/trace-viewer/components/trace-context-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/trace-context-component.tsx
@@ -7,13 +7,14 @@ import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descri
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TimeRange } from '../../../common/utils/time-range';
-import { AbstractOutputProps } from './abstract-output-component';
 import { TableOutputComponent } from './table-output-component';
 import { TimegraphOutputComponent } from './timegraph-output-component';
 import { OutputComponentStyle } from './utils/output-component-style';
 import { TimeAxisComponent } from './utils/time-axis-component';
 import { TimeNavigatorComponent } from './utils/time-navigator-component';
 import { XYOutputComponent } from './xy-output-component';
+import { NullOutputComponent } from './null-output-component';
+import { AbstractOutputProps } from './abstract-output-component';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -220,7 +221,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
                         case 'TABLE':
                             return <TableOutputComponent key={output.id} {...outputProps} />;
                         default:
-                            break;
+                            return <NullOutputComponent key={output.id} {...outputProps} />;
                     }
                 })}
             </ResponsiveGridLayout>


### PR DESCRIPTION
For example, provider type DATA_TREE is currently not implemented and
when selecting such provider (e.g. Function Duration Statistics) the
trace container crashes and the trace has to be closed first before
being able to continue.

This patch shows avoids the crash and shows a warning message instead.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>