### PR TITLE
Align code with the TSP specification

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/abstract-tree-output-component.tsx
@@ -2,7 +2,6 @@ import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } fro
 import * as React from 'react';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
-import { Entry, EntryHeader } from 'tsp-typescript-client/lib/models/entry';
 
 export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
     renderMainArea(): React.ReactNode {
@@ -36,9 +35,9 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
         // TODO Use the output descriptor to find out if the analysis is completed
         const xyTreeParameters = QueryHelper.selectionTimeQuery(
             QueryHelper.splitRangeIntoEqualParts(this.props.range.getstart(), this.props.range.getEnd(), 1120), []);
-        let xyTreeResponse = (await tspClient.fetchXYTree<Entry, EntryHeader>(traceUUID, outPutId, xyTreeParameters)).getModel();
+        let xyTreeResponse = (await tspClient.fetchXYTree(traceUUID, outPutId, xyTreeParameters)).getModel();
         while (xyTreeResponse.status === ResponseStatus.RUNNING) {
-            xyTreeResponse = (await tspClient.fetchXYTree<Entry, EntryHeader>(traceUUID, outPutId, xyTreeParameters)).getModel();
+            xyTreeResponse = (await tspClient.fetchXYTree(traceUUID, outPutId, xyTreeParameters)).getModel();
         }
         this.setState({
             outputStatus: xyTreeResponse.status

--- a/viewer-prototype/src/browser/trace-viewer/components/data-providers/style-provider.ts
+++ b/viewer-prototype/src/browser/trace-viewer/components/data-providers/style-provider.ts
@@ -89,6 +89,7 @@ export class StyleProvider {
             const styleModel = styleResponse.getModel().model;
             const styles = styleModel.styles;
             this.styles = styles;
+            return styles;
         }
         return this.styles;
     }

--- a/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
@@ -3,7 +3,6 @@ import { AbstractOutputComponent, AbstractOutputProps, AbstractOutputState } fro
 import * as React from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import { ColDef, IDatasource, GridReadyEvent } from 'ag-grid-community';
-import { Entry, EntryHeader } from 'tsp-typescript-client/lib/models/entry';
 import { QueryHelper } from 'tsp-typescript-client/lib/models/query/query-helper';
 import { cloneDeep } from 'lodash';
 
@@ -125,8 +124,8 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
         const outPutId = this.props.outputDescriptor.id;
 
         // Fetch columns
-        const columnsResponse = (await tspClient.fetchTableColumns<Entry, EntryHeader>(traceUUID, outPutId, QueryHelper.timeQuery([0, 1]))).getModel();
-        const columnEntries = columnsResponse.model.entries;
+        const columnsResponse = (await tspClient.fetchTableColumns(traceUUID, outPutId, QueryHelper.timeQuery([0, 1]))).getModel();
+        const columnEntries = columnsResponse.model;
         const colIds: Array<number> = [];
         const columnsArray = new Array<any>();
 
@@ -140,16 +139,12 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             colIds.push(0);
         }
 
-        columnEntries.forEach(entry => {
-            const id = this.showIndexColumn ? ++entry.id : entry.id;
+        columnEntries.forEach(columnHeader => {
+            const id = this.showIndexColumn ? ++columnHeader.id : columnHeader.id;
             colIds.push(id);
-            let columnName = '';
-            if (entry.labels.length) {
-                columnName = entry.labels[0];
-            }
             columnsArray.push({
-                headerName: columnName,
-                field: entry.id.toString(),
+                headerName: columnHeader.name,
+                field: columnHeader.id.toString(),
                 width: this.props.columnWidth
             });
         });

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/column-header.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/column-header.tsx
@@ -1,0 +1,5 @@
+export default interface ColumnHeader {
+    title: string,
+    tooltip?: string,
+    sortable?: boolean
+}

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/entry-tree.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/entry-tree.tsx
@@ -3,6 +3,7 @@ import { Entry } from 'tsp-typescript-client/lib/models/entry';
 import { listToTree } from './utils';
 import { FilterTree } from './tree';
 import { TreeNode } from './tree-node';
+import ColumnHeader from './column-header';
 
 interface EntryTreeProps {
     entries: Entry[];
@@ -14,6 +15,7 @@ interface EntryTreeProps {
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
     onOrderChange: (ids: number[]) => void;
     showHeader: boolean;
+    headers: ColumnHeader[];
     className: string;
 }
 
@@ -22,7 +24,8 @@ export class EntryTree extends React.Component<EntryTreeProps> {
         showFilter: true,
         onOrderChange: () => { /* Nothing to do */ },
         showHeader: true,
-        className: 'table-tree'
+        className: 'table-tree',
+        headers: [{title: 'Name', sortable: true}]
     };
 
     constructor(props: EntryTreeProps) {
@@ -34,7 +37,7 @@ export class EntryTree extends React.Component<EntryTreeProps> {
 
     render(): JSX.Element {
         return <FilterTree
-            nodes={listToTree(this.props.entries)}
+            nodes={listToTree(this.props.entries, this.props.headers)}
             {...this.props}
         />;
     }

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/sort.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/sort.tsx
@@ -15,6 +15,7 @@ export const sortState: SortState = {
 
 export interface SortConfig {
     column: string;
+    columnIndex: number;
     sortState: React.ReactNode;
 }
 
@@ -33,10 +34,10 @@ export const sortNodes = (nodes: TreeNode[], sortConfig: SortConfig[]): TreeNode
     const orderToSort = sortConfig.find((config: SortConfig) => config.sortState !== sortState.default);
     if (orderToSort) {
         sortedNodes.sort((node1: TreeNode, node2: TreeNode) => {
-            const key = orderToSort.column;
+            const index = orderToSort.columnIndex;
             const order = (orderToSort.sortState === sortState.asc) ? 'asc' : 'desc';
-            const value1 = node1[key as keyof TreeNode];
-            const value2 = node2[key as keyof TreeNode];
+            const value1 = node1.labels[index];
+            const value2 = node2.labels[index];
             let result = 0;
             if (!value1 && value2) {
                 result = -1;
@@ -46,7 +47,7 @@ export const sortNodes = (nodes: TreeNode[], sortConfig: SortConfig[]): TreeNode
                 result = 0;
             } else {
                 if (typeof value1 === 'string' && typeof value2 === 'string') {
-                    const comp = value1.localeCompare(value2);
+                    const comp = (value1 as string).localeCompare(value2);
                     result = (order === 'asc') ? -comp : comp;
                 } else {
                     if (value1 < value2) {

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-body.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-body.tsx
@@ -4,7 +4,6 @@ import { TableRow } from './table-row';
 
 interface TableBodyProps {
     nodes: TreeNode[];
-    keys: string[];
     collapsedNodes: number[];
     isCheckable: boolean;
     getCheckedStatus: (id: number) => number;

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-cell.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-cell.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { TreeNode } from './tree-node';
 
 interface TableCellProps {
-    nodeKey: string;
     node: TreeNode;
+    index: number;
 }
 
 export class TableCell extends React.Component<TableCellProps> {
@@ -12,11 +12,9 @@ export class TableCell extends React.Component<TableCellProps> {
     }
 
     render(): React.ReactNode {
-        const content: React.ReactNode = (this.props.nodeKey !== 'Legend')
-            ? this.props.node[this.props.nodeKey as keyof TreeNode]
-            : undefined;
+        const content = this.props.node.labels[this.props.index];
         return (
-            <td key={this.props.nodeKey+'-'+this.props.node.id}>
+            <td key={this.props.index+'-td-'+this.props.node.id}>
                 {this.props.children}
                 {content}
             </td>

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-header.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-header.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { SortConfig } from './sort';
+import ColumnHeader from './column-header';
 
 interface TableHeaderProps {
-    columns: string[];
+    columns: ColumnHeader[];
     sortableColumns: string[];
     sortConfig: SortConfig[];
     onSort: (sortColumn: string) => void;
@@ -29,10 +30,10 @@ export class TableHeader extends React.Component<TableHeaderProps> {
         return undefined;
     };
 
-    renderHeader = (): React.ReactNode => this.props.columns.map((column: string, index) =>
-        <th key={'th-'+index} onClick={() => this.handleSortChange(column)}>
-            {this.toCapitalCase(column)}
-            {this.renderSortIcon(column)}
+    renderHeader = (): React.ReactNode => this.props.columns.map((column: ColumnHeader, index) =>
+        <th key={'th-'+index} onClick={() => this.handleSortChange(column.title)}>
+            {this.toCapitalCase(column.title)}
+            {this.renderSortIcon(column.title)}
         </th>
     );
 

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-row.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/table-row.tsx
@@ -6,7 +6,6 @@ import icons from './icons';
 
 interface TableRowProps {
     node: TreeNode;
-    keys: string[];
     level: number;
     collapsedNodes: number[];
     isCheckable: boolean;
@@ -49,7 +48,7 @@ export class TableRow extends React.Component<TableRowProps> {
                 : <span style={{marginLeft: 5}}></span>;
     };
 
-    renderRow = (): React.ReactNode => this.props.keys.map((nodeKey: string, index) => {
+    renderRow = (): React.ReactNode => this.props.node.labels.map((_label: string, index) => {
         let toggleCollapse: React.ReactNode;
         let toggleCheck: React.ReactNode;
         if (index === 0) {
@@ -57,7 +56,7 @@ export class TableRow extends React.Component<TableRowProps> {
             toggleCheck = this.renderCheckbox();
         }
 
-        return <TableCell key={this.props.node.id+'-'+index} nodeKey={nodeKey} node={this.props.node}>
+        return <TableCell key={this.props.node.id+'-'+index} index={index} node={this.props.node}>
             {toggleCollapse}
             {toggleCheck}
         </TableCell>;

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/tree-node.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/tree-node.tsx
@@ -1,7 +1,7 @@
 export interface TreeNode {
     id: number;
     parentId: number;
-    name: string;
+    labels: string[];
     children: Array<TreeNode>;
     isRoot: boolean;
 }

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/tree.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/tree.tsx
@@ -5,6 +5,7 @@ import { Filter } from './filter';
 import { Table } from './table';
 import { getAllExpandedNodeIds } from './utils';
 import { SortConfig, sortNodes } from './sort';
+import ColumnHeader from './column-header';
 
 interface FilterTreeProps {
     nodes: TreeNode[];
@@ -16,6 +17,7 @@ interface FilterTreeProps {
     onToggleCollapse: (id: number, nodes: TreeNode[]) => void;
     onOrderChange: (ids: number[]) => void;
     showHeader: boolean;
+    headers: ColumnHeader[];
     className: string;
 }
 
@@ -213,7 +215,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     };
 
     getMatchingIds = (node: TreeNode, filter: string, foundIds: number[]): boolean => {
-        let isMatching = node.name.indexOf(filter) > -1;
+        let isMatching = node.labels[0].indexOf(filter) > -1;
         if (node.children && node.children.length) {
             node.children.forEach((child: TreeNode) => {
                 const hasMatchingChild = this.getMatchingIds(child, filter, foundIds);
@@ -253,6 +255,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             onSort={this.handleOrderChange}
             onSortConfigChange={this.handleSortConfigChange}
             showHeader={this.props.showHeader}
+            headers={this.props.headers}
             className={this.props.className}
         />;
 

--- a/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/utils.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/utils/filtrer-tree/utils.tsx
@@ -1,19 +1,29 @@
 import { Entry } from 'tsp-typescript-client/lib/models/entry';
 import { TreeNode } from './tree-node';
+import ColumnHeader from './column-header';
 
-const entryToTreeNode = (entry: Entry) => ({
-        name: ((entry.labels) && (entry.labels.length > 0)) ? entry.labels[0] : '',
+const entryToTreeNode = (entry: Entry, headers: ColumnHeader[]) => {
+    // TODO Instead of padding the labels, ColumnHeader should use a getter function  instead of just assuming strings, this will allow to get the legend for XY charts
+    const labels = ((entry.labels) && (entry.labels.length > 0)) ? entry.labels : [''];
+    // Pad the labels to match the header count
+    for (let i = labels.length; i <= headers.length - 1; i++) {
+        labels[i] = '';
+    }
+    return ({
+        labels: labels,
         isRoot: false,
-        children: [],
-        ...entry
+        id: entry.id,
+        parentId: entry.parentId,
+        children: []
     } as TreeNode);
+};
 
-export const listToTree = (list: Entry[]): TreeNode[] => {
+export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] => {
     const rootNodes: TreeNode[] = [];
     const lookup: { [key: string]: TreeNode } = {};
     // Fill-in the lookup table
     list.forEach(entry => {
-        lookup[entry.id] = entryToTreeNode(entry);
+        lookup[entry.id] = entryToTreeNode(entry, headers);
     });
     // Create the tree in the order it has been received
     list.forEach(entry => {

--- a/viewer-prototype/src/common/utils/value-hash.ts
+++ b/viewer-prototype/src/common/utils/value-hash.ts
@@ -1,0 +1,23 @@
+/**
+ * Transforms a string value to a numerical value, either parsing the string as
+ * a number or by running some kind of hash function on the string. This
+ * function for a same string will always return the same result.
+ *
+ * @param str the string value to hash
+ */
+const hash = (str: string): number => {
+    const int = parseInt(str);
+    if (!isNaN(int)) {
+        return int;
+    }
+    // Based on https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+    let hashCode = 0;
+    for (let i = 0; i < str.length; i++) {
+        const chr = str.charCodeAt(i);
+        hashCode = ((hashCode << 5) - hashCode) + chr;
+        hashCode |= 0; // Convert to 32bit integer
+    }
+    return hashCode;
+};
+
+export default hash;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13648,9 +13648,9 @@ tslint@^5.20.1:
     tsutils "^2.29.0"
 
 tsp-typescript-client@next:
-  version "0.2.0-next.85560d3"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.85560d3.tgz#083281fac24725c48585e6d352a12a1e0202f045"
-  integrity sha512-MUr6iD+LKTs6wzXni21NUQz0CsQA731+zMfyqYRWycsu60RzcpQTFwwVFn9dKzllzKD4/l2N+ZR7NaY1Y5pg8A==
+  version "0.2.0-next.339f1e7"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.339f1e7.tgz#de2190af8ff6e1773211d601d53e7755c4a142e6"
+  integrity sha512-cIPbP+uZpNOQTvRHJHQYdHdCZY7Qq5TJSPkbilN/qGG3LSgjfNQgXoWJfoA2RK/n1l3yOTs3CAN5YYqHtPFUlA==
   dependencies:
     node-fetch "^2.5.0"
 


### PR DESCRIPTION
The trace server protocol and the tsp-typescript-client have been
updated. This makes the trace extension match the newer versions.

It updates the filter-tree (left part of xy and timegraphs) to use
labels and column headers instead of extra keys.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>