### PR TITLE
Add support for column resizing

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/components/table-output-component.tsx
@@ -61,6 +61,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 debug={this.debugMode}
                 onGridReady={this.onGridReady}
                 components={this.components}
+                enableColResize={true}
             >
             </AgGridReact>
         </div>;
@@ -146,6 +147,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
                 headerName: columnHeader.name,
                 field: columnHeader.id.toString(),
                 width: this.props.columnWidth
+
             });
         });
 


### PR DESCRIPTION
By setting the enableColResize property to true on the ag-grid,
users can resize any columns in the events table.

Signed-off-by: Ankush Tyagi <ankush.tyagi@ericsson.com>