### PR TITLE
Close traces after experiment and handle deletion rejection

### DIFF
--- a/packages/base/src/trace-manager.ts
+++ b/packages/base/src/trace-manager.ts
@@ -120,10 +120,12 @@ export class TraceManager {
     async closeTrace(traceUUID: string): Promise<void> {
         const traceToClose = this.fOpenTraces.get(traceUUID);
         if (traceToClose) {
-            await this.fTspClient.deleteTrace(traceUUID);
-            const deletedTrace = this.removeTrace(traceUUID);
-            if (deletedTrace) {
-                signalManager().emit(Signals.TRACE_CLOSED, {trace: deletedTrace});
+            const deleteResponse = await this.fTspClient.deleteTrace(traceUUID);
+            if (deleteResponse.getStatusCode() !== 409) {
+                const deletedTrace = this.removeTrace(traceUUID);
+                if (deletedTrace) {
+                    signalManager().emit(Signals.TRACE_CLOSED, {trace: deletedTrace});
+                }
             }
         }
     }

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -112,20 +112,8 @@ export class TraceViewerWidget extends ReactWidget {
 
     onCloseRequest(msg: Message): void {
         if (this.openedExperiment) {
-
-            const traces = this.openedExperiment.traces;
             // Close experiment
             this.experimentManager.closeExperiment(this.openedExperiment.UUID);
-
-            /*
-             TODO:
-             Decide wheather to delete traces from server as well.
-             Other experiments might wan to be create with these traces.
-            */
-            // Close each trace
-            for (let i = 0; i < traces.length; i++) {
-                this.traceManager.closeTrace(traces[i].UUID);
-            }
         }
         this.statusBar.removeElement('time-selection-range');
         super.onCloseRequest(msg);

--- a/viewer-prototype/src/browser/tsp-client-provider.ts
+++ b/viewer-prototype/src/browser/tsp-client-provider.ts
@@ -17,12 +17,12 @@ export class TspClientProvider {
     ) {
         this._tspClient = new TspClient(this.tspUrlProvider.getTraceServerUrl());
         this._traceManager = new TraceManager(this._tspClient);
-        this._experimentManager = new ExperimentManager(this._tspClient);
+        this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
         this._listeners = [];
         tspUrlProvider.addTraceServerUrlChangedListener(url => {
             this._tspClient = new TspClient(url);
             this._traceManager = new TraceManager(this._tspClient);
-            this._experimentManager = new ExperimentManager(this._tspClient);
+            this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
             this._listeners.forEach(listener => listener(this._tspClient));
         });
     }


### PR DESCRIPTION
Wait for experiment deletion response to be received before attempting
to close its traces.

Handle trace and experiment deletion response and do not remove it from
its manager if the deletion was rejected by the trace server.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>