### PR TITLE
Add preference settings for trace configuration

### DIFF
--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -8,7 +8,10 @@
       "config": {
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
-          "editor.autoSave": "on"
+          "editor.autoSave": "on",
+          "trace-viewer.path" : "../trace-compass-server/tracecompass-server",
+          "trace-viewer.port" : 8080
+
         }
       }
     }

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -17,7 +17,9 @@
       "config": {
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
-          "editor.autoSave": "on"
+          "editor.autoSave": "on",
+          "trace-viewer.path" : "../trace-compass-server/tracecompass-server",
+          "trace-viewer.port" : 8080
         }
       }
     }

--- a/viewer-prototype/package.json
+++ b/viewer-prototype/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "theia-trace-viewer",
-    "private": "true",
-    "version": "0.0.0",
-    "description": "Trace Compass trace viewer Theia Extension",
-    "keywords": [
-        "theia-extension"
-    ],
-    "license": "MIT",
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/theia-ide/theia-trace-extension"
-    },
-    "files": [
-      "lib",
-      "src"
-    ],
-    "dependencies": {
-      "@trace-viewer/base": "0.0.0",
-      "@trace-viewer/react-components": "0.0.0",
-      "@theia/core": "latest",
-      "@theia/editor": "latest",
-      "@theia/filesystem": "latest"
-    },
-    "devDependencies": {
-      "@typescript-eslint/eslint-plugin": "^3.4.0",
-      "@typescript-eslint/parser": "^3.4.0",
-      "eslint": "^7.3.0",
-      "eslint-plugin-import": "^2.21.2",
-      "eslint-plugin-no-null": "^1.0.2",
-      "eslint-plugin-react": "^7.20.0",
-      "rimraf": "latest",
-      "typescript": "latest"
-    },
-    "scripts": {
-      "build": "tsc",
-      "clean": "rimraf lib",
-      "lint": "eslint .",
-      "prepare": "yarn run clean && yarn run build",
-      "test": "echo 'test'",
-      "watch": "tsc -w"
-    },
-    "theiaExtensions": [
-        {
-          "frontend": "lib/browser/trace-viewer/trace-viewer-frontend-module"
-        }
-    ]
-  }
-  
+  "name": "theia-trace-viewer",
+  "private": "true",
+  "version": "0.0.0",
+  "description": "Trace Compass trace viewer Theia Extension",
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia-trace-extension"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "@trace-viewer/base": "0.0.0",
+    "@trace-viewer/react-components": "0.0.0",
+    "@theia/core": "latest",
+    "@theia/editor": "latest",
+    "@theia/filesystem": "latest"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.4.0",
+    "@typescript-eslint/parser": "^3.4.0",
+    "eslint": "^7.3.0",
+    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-no-null": "^1.0.2",
+    "eslint-plugin-react": "^7.20.0",
+    "rimraf": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "lint": "eslint .",
+    "prepare": "yarn run clean && yarn run build",
+    "test": "echo 'test'",
+    "watch": "tsc -w"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/trace-viewer/trace-viewer-frontend-module",
+      "backend": "lib/node/trace-server-backend-module"
+    }
+  ]
+}

--- a/viewer-prototype/src/browser/trace-server-bindings.ts
+++ b/viewer-prototype/src/browser/trace-server-bindings.ts
@@ -1,0 +1,15 @@
+import { interfaces } from 'inversify';
+import { PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser';
+import { TracePreferences, ServerSchema } from './trace-server-preference';
+
+export function bindTraceServerPreferences(bind: interfaces.Bind): void {
+    bind(TracePreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createPreferenceProxy(preferences, ServerSchema);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({
+        schema: ServerSchema,
+    });
+
+}

--- a/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/viewer-prototype/src/browser/trace-server-preference.ts
@@ -1,0 +1,30 @@
+import { PreferenceSchema, PreferenceProxy, PreferenceScope } from '@theia/core/lib/browser';
+
+export const TRACE_PATH = 'trace-viewer.path';
+export const TRACE_PORT = 'trace-viewer.port';
+
+export const ServerSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [TRACE_PATH]: {
+            'type': 'string',
+            'default': '',
+            'description': 'The path to trace-server executable, e.g.: /usr/bin/tracecompass-server',
+        },
+        [TRACE_PORT]: {
+            'type': 'number',
+            'default': '',
+            'description': 'Specify the port on which you want to execute the server.',
+        }
+
+    },
+    scope: PreferenceScope.Folder,
+};
+
+interface TracePreferenceContribution {
+    [TRACE_PATH]: string;
+    [TRACE_PORT]: number;
+}
+
+export const TracePreferences = Symbol('TracePreferences');
+export type TracePreferences = PreferenceProxy<TracePreferenceContribution>;

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -1,5 +1,5 @@
 import { ContainerModule, Container } from 'inversify';
-import { WidgetFactory, OpenHandler, FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
+import { WidgetFactory, OpenHandler, FrontendApplicationContribution, bindViewContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { TraceViewerContribution } from './trace-viewer-contribution';
 import { TraceViewerEnvironment } from '../../common/trace-viewer-environment';
@@ -10,16 +10,14 @@ import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-balham-dark.css';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
-// import 'semantic-ui-css/semantic.min.css';
 import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-contribution';
 import { TRACE_EXPLORER_ID, TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TspClientProvider } from '../tsp-client-provider';
 import { TheiaMessageManager } from '../theia-message-manager';
 import { TraceServerConnectionStatusService, TraceServerConnectionStatusContribution } from '../../browser/trace-server-status';
 import { TraceServerUrlProviderImpl } from '../trace-server-url-provider-frontend-impl';
-// import { TracePropertiesContribution } from '../trace-properties-view/trace-properties-view-contribution';
-// import { TracePropertiesWidget, TRACE_PROPERTIES_ID } from '../trace-properties-view/trace-properties-view-widget';
-
+import { bindTraceServerPreferences } from '../trace-server-bindings';
+import { TraceServerConfigService, traceServerPath } from '../../common/trace-server-config';
 export default new ContainerModule(bind => {
 
     bind(TraceViewerEnvironment).toSelf().inRequestScope();
@@ -53,10 +51,17 @@ export default new ContainerModule(bind => {
         createWidget: () => context.container.get<TraceExplorerWidget>(TraceExplorerWidget)
     }));
 
+    bind(TraceServerConfigService).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<TraceServerConfigService>(traceServerPath);
+    }).inSingletonScope();
+
     bind(TraceServerConnectionStatusService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusService);
     bind(TraceServerConnectionStatusContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusContribution);
+
+    bindTraceServerPreferences(bind);
 
     // bindViewContribution(bind, TracePropertiesContribution);
     // bind(TracePropertiesWidget).toSelf();

--- a/viewer-prototype/src/common/trace-server-config.ts
+++ b/viewer-prototype/src/common/trace-server-config.ts
@@ -1,0 +1,15 @@
+
+export const traceServerPath = '/services/trace-server-config';
+export const TraceServerConfigService = Symbol('TraceServerConfigService');
+export interface TraceServerConfigService {
+    /**
+     * Spawn the trace server from a given path
+     */
+    startTraceServer(path: string | undefined, port: number | undefined): Promise<void>;
+
+    /**
+     * Stop the trace server
+     */
+    stopTraceServer(port: number | undefined): Promise<void>;
+}
+

--- a/viewer-prototype/src/common/trace-server-url-provider.ts
+++ b/viewer-prototype/src/common/trace-server-url-provider.ts
@@ -1,5 +1,7 @@
 export const TraceServerUrlProvider = Symbol('TraceServerUrlProvider');
-export const TRACE_SERVER_DEFAULT_URL = 'http://localhost:8080/tsp/api';
+export const TRACE_SERVER_DEFAULT_URL = 'http://localhost:{}/tsp/api';
+export const TRACE_SERVER_DEFAULT_PORT = '8080';
+
 export interface TraceServerUrlProvider {
 
     /**

--- a/viewer-prototype/src/node/index.ts
+++ b/viewer-prototype/src/node/index.ts
@@ -1,0 +1,2 @@
+export * from './trace-server-backend-module';
+export * from './trace-server-service';

--- a/viewer-prototype/src/node/trace-server-backend-module.ts
+++ b/viewer-prototype/src/node/trace-server-backend-module.ts
@@ -1,0 +1,16 @@
+import { ContainerModule } from 'inversify';
+import { TraceServerServiceImpl } from './trace-server-service';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { traceServerPath } from '../common/trace-server-config';
+import { TraceServerConfigService } from '../common/trace-server-config';
+
+export default new ContainerModule(bind => {
+    bind(TraceServerServiceImpl).toSelf().inSingletonScope();
+
+    bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler<TraceServerConfigService>(
+        traceServerPath,
+        () => ctx.container.get<TraceServerConfigService>(TraceServerServiceImpl),
+    )).inSingletonScope();
+
+});

--- a/viewer-prototype/src/node/trace-server-service.ts
+++ b/viewer-prototype/src/node/trace-server-service.ts
@@ -1,0 +1,14 @@
+import { spawn, exec } from 'child_process';
+import { injectable } from 'inversify';
+import { TraceServerConfigService } from '../common/trace-server-config';
+@injectable()
+export class TraceServerServiceImpl implements TraceServerConfigService {
+
+    async startTraceServer(path: string | undefined, port: number | undefined): Promise<void> {
+        spawn(`${path}`, ['-vmargs', `-Dtraceserver.port=${port}`]);
+    }
+
+    async stopTraceServer(port: number | undefined): Promise<void> {
+        exec(`kill -9 $(lsof -t -i:${port} -sTCP:LISTEN)`);  // FIXME: Better approach to kill the server at a given port
+    }
+}

--- a/viewer-prototype/tsconfig.json
+++ b/viewer-prototype/tsconfig.json
@@ -9,7 +9,7 @@
         "moduleResolution": "node",
         "skipLibCheck": true,
         "esModuleInterop": true,
-        "target": "ESNEXT",
+        "target": "es5",
         "jsx": "react",
         "lib": [
             "es6",
@@ -18,7 +18,11 @@
         "sourceMap": true,
         "rootDir": "src",
         "outDir": "lib",
-        "types": ["node", "jest"]
+        "types": [
+            "node",
+            "jest"
+        ],
+        "strictPropertyInitialization": false
     },
     "include": [
         "src"
@@ -28,4 +32,4 @@
         "**/*.spec.ts",
         "**/*.test.ts"
     ]
-} 
+}


### PR DESCRIPTION
Set the default values for the trace server preferences
Read the trace server preference values and spawn the server from the path specified in the
preferences

fixes #191
fixes #184

Signed-off-by: Ankush Tyagi ankush.tyagi@ericsson.com