### PR TITLE
Fixed placeholder text positioning and updated placeholder text

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -265,7 +265,9 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
 
     private renderPlaceHolder() {
         return <div className='no-output-placeholder'>
-            {'Add outputs by clicking on an analysis in the trace explorer view'}
+            {'Trace loaded successfully.'}
+            <br />
+            {'To see available analyses, open the Trace Explorer view.'}
         </div>;
     }
 

--- a/packages/react-components/src/style/trace-context-style.css
+++ b/packages/react-components/src/style/trace-context-style.css
@@ -1,7 +1,12 @@
 .no-output-placeholder {
     color: var(--theia-ui-font-color3);
     font-size: 24px;
-    transform: translate(30%, 500%);
+    text-align: center;
+    position: relative;
+    transform: translate(0, -50%);
+    top: 50%;
+    width: 90%;
+    align-self: center;
 }
 
 .react-grid-item.react-grid-placeholder {


### PR DESCRIPTION
This PR fixes the positioning of the placeholder text when opening a trace. Previously the text was off-centered and non-responsive such that the text would be cut-off in certain viewport widths.

This PR also updates the text based on @ssmagula's recommendations. I understand there is a desire to obviate this step in future iterations, but this should improve things in the meantime!

| Before | After |
| ------ | ------ |
|![image](https://user-images.githubusercontent.com/14880569/103942654-5731f200-50f6-11eb-9a39-ccf4890c54fa.png)|![image](https://user-images.githubusercontent.com/14880569/103942578-3d90aa80-50f6-11eb-9340-2d984476a45c.png)|