### PR TITLE
Support inband OutputElementStyle for annotations

### DIFF
--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -377,23 +377,24 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             if (metadata && metadata.style) {
                 const elementStyle: OutputElementStyle = metadata.style;
                 const modelStyle = styleModel.styles[elementStyle.parentKey];
+                let currentStyle = Object.assign({}, elementStyle.values);
                 if (modelStyle) {
-                    const currentStyle = Object.assign({}, modelStyle.values, elementStyle.values);
-                    if (currentStyle) {
-                        let color = 0;
-                        if (currentStyle['color']) {
-                            color = this.hexStringToNumber(currentStyle['color']);
-                        }
-                        let symbolSize = this.props.style.rowHeight * 0.8 / 2;
-                        if (currentStyle['height']) {
-                            symbolSize = currentStyle['height'] * symbolSize;
-                        }
-                        return {
-                            symbol: currentStyle['symbol-type'],
-                            size: symbolSize,
-                            color: color
-                        };
+                    currentStyle = Object.assign({}, modelStyle.values, elementStyle.values);
+                }
+                if (currentStyle) {
+                    let color = 0;
+                    if (currentStyle['color']) {
+                        color = this.hexStringToNumber(currentStyle['color']);
                     }
+                    let symbolSize = this.props.style.rowHeight * 0.8 / 2;
+                    if (currentStyle['height']) {
+                        symbolSize = currentStyle['height'] * symbolSize;
+                    }
+                    return {
+                        symbol: currentStyle['symbol-type'],
+                        size: symbolSize,
+                        color: color
+                    };
                 }
             }
         }


### PR DESCRIPTION
To provide annotation markers the output styles needed to defined
in the list of style provided through the fetch style method which
are referenced by the parent style key in the annotation itself.

This patch makes it possible to supply the OutputElementStyle inside
the annotation without using the parent style key.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>