### PR TITLE
trace-explorer: update options to make view closable

### DIFF
--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -74,6 +74,7 @@ export class TraceExplorerWidget extends ReactWidget {
         this.title.label = TRACE_EXPLORER_LABEL;
         this.title.caption = TRACE_EXPLORER_LABEL;
         this.title.iconClass = 'trace-explorer-tab-icon';
+        this.title.closable = true;
         this.experimentManager = this.tspClientProvider.getExperimentManager();
         signalManager().on(Signals.EXPERIMENT_OPENED, ({ experiment }) => this.onExperimentOpened(experiment));
         signalManager().on(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));


### PR DESCRIPTION
**What it does**

Fixes https://github.com/theia-ide/theia-trace-extension/issues/215

The following commit updates the `trace-explorer-widget` so that it is closable (using the `title.closable` option (which is ultimately used by the `close` command in the shell tabbar.

![close-trace](https://user-images.githubusercontent.com/40359487/104472923-744d4180-558a-11eb-8db3-8200622127ff.gif)

- [Reference](https://github.com/eclipse-theia/theia/blob/db4b2e7159aa68f09577dfc212909d97f3e2d1af/packages/core/src/browser/common-frontend-contribution.ts#L648-L656).

**How to test**

- build the changes and start the application
- right-click on the `trace explorer` tab and select `close`
- the view should close

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>