### PR TITLE
Use the checkHealth method to check server status

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-status.ts
@@ -16,6 +16,8 @@ import { PreferenceService } from '@theia/core/lib/browser';
 import { TRACE_PATH, TRACE_PORT } from './trace-server-preference';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { MessageService } from '@theia/core';
+import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
+import { HealthStatus } from 'tsp-typescript-client/lib/models/health';
 
 @injectable()
 export class TraceServerConnectionStatusService extends AbstractConnectionStatusService {
@@ -41,8 +43,8 @@ export class TraceServerConnectionStatusService extends AbstractConnectionStatus
             this.lastPing.reject();
             this.lastPing = new Deferred();
             try {
-                await Promise.race([this.tspClient.fetchExperiments(), this.lastPing.promise]);
-                this.updateStatus(true);
+                const healthResponse = await Promise.race([this.tspClient.checkHealth(), this.lastPing.promise]);
+                this.updateStatus((healthResponse as TspClientResponse<HealthStatus>).getModel()?.status === 'UP');
             } catch (e) {
                 this.updateStatus(false);
                 this.logger.trace(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15535,9 +15535,9 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsp-typescript-client@next:
-  version "0.2.0-next.799187d"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.799187d.tgz#3e2073014b942f6b7d130dccaa8091493856b9d2"
-  integrity sha512-TXPzObPEWLzJgqgrPrrOCA8ri3lHOuzZLDEyniPDUfHbMK06et6ivBsXIYaRwXllw3IHGgtE5Rzf3CTrmOL94Q==
+  version "0.2.0-next.5f4f154"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.5f4f154.tgz#5ef1c569e4a3950f7a2da5705de32d7ebcb0f7dc"
+  integrity sha512-vJPuIPBuAzju8BRZ6SpSfkTUNiSNuDjcZ7rElZQUd6aEqerx1/M9qKhbVED2dPbpEJF1nd9zNZusrQNjvFyxxg==
   dependencies:
     node-fetch "^2.5.0"
 


### PR DESCRIPTION
Closes #70

Instead of requested the experiments to see if the server is alive, use
the more light-weight checkHealth method.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>