### PR TITLE
Support error handling for start/stop trace server

### DIFF
--- a/viewer-prototype/package.json
+++ b/viewer-prototype/package.json
@@ -30,7 +30,8 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-react": "^7.20.0",
     "rimraf": "latest",
-    "typescript": "latest"
+    "typescript": "latest",
+    "tree-kill": "latest"
   },
   "scripts": {
     "build": "tsc",

--- a/viewer-prototype/src/common/trace-server-config.ts
+++ b/viewer-prototype/src/common/trace-server-config.ts
@@ -1,15 +1,20 @@
+import { ApplicationError } from '@theia/core';
 
 export const traceServerPath = '/services/trace-server-config';
 export const TraceServerConfigService = Symbol('TraceServerConfigService');
+export const PortBusy = ApplicationError.declare(-32650, code => ({
+    message: 'Port busy',
+    data: { code }
+}));
 export interface TraceServerConfigService {
     /**
      * Spawn the trace server from a given path
      */
-    startTraceServer(path: string | undefined, port: number | undefined): Promise<void>;
+    startTraceServer(path: string | undefined, port: number | undefined): Promise<string>;
 
     /**
      * Stop the trace server
      */
-    stopTraceServer(port: number | undefined): Promise<void>;
+    stopTraceServer(): Promise<string>;
 }
 

--- a/viewer-prototype/src/node/trace-server-service.ts
+++ b/viewer-prototype/src/node/trace-server-service.ts
@@ -1,33 +1,56 @@
-import { spawn, exec } from 'child_process';
+import { spawn } from 'child_process';
 import { injectable } from 'inversify';
-import { TraceServerConfigService } from '../common/trace-server-config';
+import { PortBusy, TraceServerConfigService } from '../common/trace-server-config';
+import treeKill = require('tree-kill');
 @injectable()
 export class TraceServerServiceImpl implements TraceServerConfigService {
+    private processId: number;
 
-    startTraceServer(path: string | undefined, port: number | undefined): Promise<void> {
+    startTraceServer(path: string | undefined, port: number | undefined): Promise<string> {
         const server = spawn(`${path}`, ['-vmargs', `-Dtraceserver.port=${port}`]);
-        return new Promise<void>((resolve, reject) => {
-            // If the server provides output on any channel before it exits, consider that a success.
+        this.processId = server.pid;
+        const timeouts: NodeJS.Timeout[] = [];
+
+        return new Promise<string>((resolve, reject) => {
+            // TODO: Since the resolve never actually gets returned, we need a better way to determine if the child process
+            // initiated by the spawn successfully starts the trace server
+
+            // If the server doesn't error or exit within 2 seconds, we consider that a success.
             // That doesn't mean that the server has really started. On the frontend, the `TraceServerConnectionStatusService`
             // will ping the port until it receives a response, which is the official measure of success.
-            server.stdout.on('data', () => resolve());
-            server.stderr.on('data', () => resolve());
+
+            timeouts.push(setTimeout(() => resolve('success'), 2000));
+
             // If the server exits or errors before it outputs, consider it a failure.
-            server.on('exit', code => reject(code));
-            server.on('error', error => reject(error));
-        })
-            .finally(() => { server.removeAllListeners(); });
+            server.on('error', err => {
+                reject(err);
+            });
+            server.on('exit', code => {
+                reject(PortBusy(code));
+            });
+            // If no response recieved from the trace server in 10 seconds, reject with an error (for internal use)
+            timeouts.push(setTimeout(() => reject('Waited 10 seconds but nothing happened and hence exiting'), 10000));
+
+        }).finally(() => {
+            server.removeAllListeners();
+            timeouts.forEach(timeout => clearTimeout(timeout));
+        });
+
     }
 
-    stopTraceServer(port: number | undefined): Promise<void> {
-        const terminator = exec(`kill -9 $(lsof -t -i:${port} -sTCP:LISTEN)`);  // FIXME: Better approach to kill the server at a given port
-        return new Promise((resolve, reject) => {
-            terminator.on('exit', code => {
-                if (code === 0 || code === 1) {
-                    resolve();
-                } else {
-                    reject(code);
+    stopTraceServer(): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            if (this.processId === -1 || !this.processId) {
+                reject('process already killed or process hasn\'t been started');
+                return;
+            }
+            treeKill(this.processId, error => {
+                this.processId = -1;
+                if (error) {
+                    reject(error);
+                    return;
                 }
+                resolve('success');
             });
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15572,6 +15572,11 @@ trash@^6.1.1:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
+tree-kill@latest:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"


### PR DESCRIPTION
Signed-off-by: Ankush Tyagi <ankush.tyagi@ericsson.com>

This PR adds error handling for the start/stop trace server. It also prevents the user from accidentally killing a process through the preferences settings. 

Steps to test:
- Provide an incorrect path for the executable and click the start trace server button. 
- Provide a busy port in the preferences settings and click the start trace server button.
You should see a Toast message with a detailed error.
  

