### PR TITLE
Panelize trace explorer + other frontend fixes

### DIFF
--- a/packages/base/src/signal-manager.ts
+++ b/packages/base/src/signal-manager.ts
@@ -25,7 +25,7 @@ export class SignalManager extends EventEmitter implements SignalManager {
         this.emit(Signals.TOOLTIP_UPDATED, { tooltip });
     }
 
-    fireThemeChangedSignal(theme: string) {
+    fireThemeChangedSignal(theme: string): void {
         this.emit(Signals.THEME_CHANGED, theme);
     }
 
@@ -37,7 +37,7 @@ export class SignalManager extends EventEmitter implements SignalManager {
 
 let instance: SignalManager = new SignalManager();
 
-export const setSignalManagerInstance = (sm: SignalManager) => {
+export const setSignalManagerInstance = (sm: SignalManager): void => {
     instance = sm;
 };
 

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -113,7 +113,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         signalManager().on(Signals.THEME_CHANGED, (theme: string) => this.updateBackgroundTheme(theme));
     }
 
-    public updateBackgroundTheme(theme: string) {
+    public updateBackgroundTheme(theme: string): void {
         this.setState({
             style: {
                 width: this.DEFAULT_COMPONENT_WIDTH,

--- a/packages/react-components/src/style/trace-explorer.css
+++ b/packages/react-components/src/style/trace-explorer.css
@@ -1,36 +1,21 @@
+:root {
+    --trace-extension-list-line-height: 16px;
+}
+
+#trace-explorer-analysis-widget,
+#trace-explorer-opened-traces-widget {
+    height: 100%;
+}
+
 .trace-explorer-tab-icon {
     -webkit-mask: url('chart-line-solid.svg');
     mask: url('chart-line-solid.svg');
 }
 
-/* Main container */
-.trace-explorer-container {
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: 1fr 1fr; /*1fr*/
-    grid-row-gap: 10px;
-    color: var(--theia-ui-font-color0);
-}
-
-.trace-explorer-opened {
-    grid-row-start: 1;
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: 25px 1fr;
-}
-
-/* .trace-explorer-files {
-    grid-row-start: 2;
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: 25px 1fr;
-} */
-
-.trace-explorer-analysis {
-    grid-row-start: 2;
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: 25px 1fr;
+.trace-explorer-opened,
+.trace-explorer-analysis,
+.trace-explorer-tooltip {
+    margin: 0 2px;
 }
 
 .trace-explorer-panel-title {
@@ -46,7 +31,6 @@
     grid-row-start: 2;
     border: 1px solid var(--theia-layout-color4);
     /* color: white; */
-    padding-inline-start: 5px;
     white-space: nowrap;
 }
 
@@ -61,18 +45,27 @@
     white-space: nowrap;
 }
 
+.trace-list-container:hover,
+.outputs-list-container:hover {
+    background-color: var(--theia-list-hoverBackground);
+    cursor: pointer;
+}
+
+.trace-list-container.theia-mod-selected,
 .outputs-list-container.theia-mod-selected {
     background-color: var(--theia-selection-background);
 }
 
-.trace-element-container {
+/* Share options have been commented out, grid is disabled to optimize horizontal space */
+/* .trace-element-container {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 50px;
     grid-template-rows: auto;
-}
+} */
 
-.trace-element-container.theia-mod-selected {
-    background-color: var(--theia-selection-background);
+/* Remove focus outline on grid when selected */
+.ReactVirtualized__Grid {
+    outline: none;
 }
 
 .trace-element-info {
@@ -82,12 +75,20 @@
 
 .trace-element-name, .outputs-element-name {
     font-weight: bold;
+    margin: unset;
+    height: var(--trace-extension-list-line-height);
 }
 
-.trace-element-path, .outputs-element-description {
+.trace-element-path-container, .outputs-element-description {
+    margin: unset;
     color: var(--theia-ui-font-color2);
     /* color: rgb(160, 160, 160); */
     white-space: pre;
+    font-size: .95em;
+}
+
+.child-element {
+    height: var(--trace-extension-list-line-height);
 }
 
 .trace-element-options {

--- a/viewer-prototype/src/browser/theia-message-manager.ts
+++ b/viewer-prototype/src/browser/theia-message-manager.ts
@@ -2,6 +2,8 @@ import * as Messages from '@trace-viewer/base/lib/message-manager';
 import { inject, injectable } from 'inversify';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser';
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 @injectable()
 export class TheiaMessageManager implements Messages.MessageManager {
 

--- a/viewer-prototype/src/browser/trace-explorer/output-added-signal-payload.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/output-added-signal-payload.tsx
@@ -1,0 +1,20 @@
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+
+export class OutputAddedSignalPayload {
+    private outputDescriptor: OutputDescriptor;
+    private experiment: Experiment;
+
+    constructor(outputDescriptor: OutputDescriptor, trace: Experiment) {
+        this.outputDescriptor = outputDescriptor;
+        this.experiment = trace;
+    }
+
+    public getOutputDescriptor(): OutputDescriptor {
+        return this.outputDescriptor;
+    }
+
+    public getExperiment(): Experiment {
+        return this.experiment;
+    }
+}

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -1,13 +1,14 @@
+import { injectable } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { TraceExplorerWidget, TRACE_EXPLORER_ID, TRACE_EXPLORER_LABEL } from './trace-explorer-widget';
+import { TraceExplorerWidget, } from './trace-explorer-widget';
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 
+@injectable()
 export class TraceExplorerContribution extends AbstractViewContribution<TraceExplorerWidget> implements FrontendApplicationContribution {
-
     constructor() {
         super({
-            widgetId: TRACE_EXPLORER_ID,
-            widgetName: TRACE_EXPLORER_LABEL,
+            widgetId: TraceExplorerWidget.ID,
+            widgetName: TraceExplorerWidget.LABEL,
             defaultWidgetOptions: {
                 area: 'left'
             },
@@ -15,8 +16,8 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
         });
     }
 
-    async initializeLayout(_app: FrontendApplication): Promise<void> {
-        await this.openView({ activate: false });
+    initializeLayout(_app: FrontendApplication): void {
+        this.openView({ activate: false });
     }
 
 }

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-analysis-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-analysis-widget.tsx
@@ -1,0 +1,133 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { ReactWidget, Widget, Message } from '@theia/core/lib/browser';
+import * as React from 'react';
+import { List, ListRowProps, AutoSizer } from 'react-virtualized';
+import { TraceExplorerOpenedTracesWidget } from './trace-explorer-opened-traces-widget';
+import { Emitter } from '@theia/core';
+import { OutputAddedSignalPayload } from '../output-added-signal-payload';
+
+@injectable()
+export class TraceExplorerAnalysisWidget extends ReactWidget {
+    static ID = 'trace-explorer-analysis-widget';
+    static LABEL = 'Available Analysis';
+    static LIST_MARGIN = 2;
+    static LINE_HEIGHT = 16;
+    static ROW_HEIGHT = (2 * TraceExplorerAnalysisWidget.LINE_HEIGHT) + TraceExplorerAnalysisWidget.LIST_MARGIN;
+
+    protected forceUpdateKey = false;
+
+    protected outputAddedEmitter = new Emitter<OutputAddedSignalPayload>();
+    outputAddedSignal = this.outputAddedEmitter.event;
+
+    @inject(TraceExplorerOpenedTracesWidget) protected readonly openedTracesWidget!: TraceExplorerOpenedTracesWidget;
+
+    @postConstruct()
+    init(): void {
+        this.id = TraceExplorerAnalysisWidget.ID;
+        this.title.label = TraceExplorerAnalysisWidget.LABEL;
+        this.toDispose.push(this.openedTracesWidget.availableOutputDescriptorsDidChange(() => {
+            this.update();
+        }));
+        this.toDispose.push(this.outputAddedEmitter);
+        this.update();
+    }
+
+    render(): React.ReactNode {
+        this.forceUpdateKey = !this.forceUpdateKey;
+        const key = Number(this.forceUpdateKey);
+        const { openedExperiments, availableOutputDescriptors, selectedExperimentIndex } = this.openedTracesWidget;
+        let outputsRowCount = 0;
+        const outputs = availableOutputDescriptors.get(openedExperiments[selectedExperimentIndex]?.UUID);
+        if (outputs) {
+            outputsRowCount = outputs.length;
+        }
+        const totalHeight = this.getTotalHeight();
+        return (
+            <div className='trace-explorer-analysis'>
+                <div className='trace-explorer-panel-content'>
+                    <AutoSizer>
+                        {({ width }) =>
+                            <List
+                                key={key}
+                                height={totalHeight}
+                                width={width}
+                                rowCount={outputsRowCount}
+                                rowHeight={TraceExplorerAnalysisWidget.ROW_HEIGHT}
+                                rowRenderer={this.renderRowOutputs}
+                            />
+                        }
+                    </AutoSizer>
+                </div>
+            </div>
+        );
+    }
+
+    protected renderRowOutputs = (props: ListRowProps): React.ReactNode => this.doRenderRowOutputs(props);
+
+    private doRenderRowOutputs(props: ListRowProps): React.ReactNode {
+        let outputName = '';
+        let outputDescription = '';
+        const { openedExperiments, availableOutputDescriptors, selectedExperimentIndex, lastSelectedOutputIndex } = this.openedTracesWidget;
+        const selectedTrace = openedExperiments[selectedExperimentIndex];
+        if (selectedTrace) {
+            const outputDescriptors = availableOutputDescriptors.get(selectedTrace.UUID);
+            if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
+                outputName = outputDescriptors[props.index].name;
+                outputDescription = outputDescriptors[props.index].description;
+            }
+        }
+        let traceContainerClassName = 'outputs-list-container';
+        if (props.index === lastSelectedOutputIndex) {
+            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
+        }
+        return <div className={traceContainerClassName}
+            id={`${traceContainerClassName}-${props.index}`}
+            key={props.key}
+            style={props.style}
+            onClick={this.handleOutputClicked}
+            data-id={`${props.index}`}
+        >
+            <h4 className='outputs-element-name'>
+                {outputName}
+            </h4>
+            <div className='outputs-element-description child-element'>
+                {outputDescription}
+            </div>
+        </div>;
+    }
+
+    protected getTotalHeight(): number {
+        let totalHeight = 0;
+        const { openedExperiments, availableOutputDescriptors, selectedExperimentIndex } = this.openedTracesWidget;
+        const selectedTrace = openedExperiments[selectedExperimentIndex];
+        if (selectedTrace) {
+            const outputDescriptors = availableOutputDescriptors.get(selectedTrace.UUID);
+            outputDescriptors?.forEach(() => totalHeight += TraceExplorerAnalysisWidget.ROW_HEIGHT);
+        }
+        return totalHeight;
+    }
+
+    protected handleOutputClicked = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOutputClicked(e);
+
+    private doHandleOutputClicked(e: React.MouseEvent<HTMLDivElement>) {
+        const index = Number(e.currentTarget.getAttribute('data-id'));
+        const { openedExperiments, selectedExperimentIndex, availableOutputDescriptors } = this.openedTracesWidget;
+        this.openedTracesWidget.lastSelectedOutputIndex = index;
+        const trace = openedExperiments[selectedExperimentIndex];
+        const outputs = availableOutputDescriptors.get(trace.UUID);
+        if (outputs) {
+            this.outputAddedEmitter.fire(new OutputAddedSignalPayload(outputs[index], trace));
+        }
+        this.update();
+    }
+
+    protected onResize(msg: Widget.ResizeMessage): void {
+        super.onResize(msg);
+        this.update();
+    }
+
+    protected onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.update();
+    }
+}

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-opened-traces-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-opened-traces-widget.tsx
@@ -1,0 +1,310 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { ReactWidget, Message, Widget } from '@theia/core/lib/browser';
+import * as React from 'react';
+import { List, ListRowProps, Index, AutoSizer } from 'react-virtualized';
+import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import { ExperimentManager } from '@trace-viewer/base/lib/experiment-manager';
+import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
+import { Emitter } from '@theia/core';
+import { TspClientProvider } from '../../tsp-client-provider';
+import { signalManager, Signals } from '@trace-viewer/base/lib/signal-manager';
+import { TraceExplorerTooltipWidget } from './trace-explorer-tooltip-widget';
+import ReactModal from 'react-modal';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+
+@injectable()
+export class TraceExplorerOpenedTracesWidget extends ReactWidget {
+    static ID = 'trace-explorer-opened-traces-widget';
+    static LABEL = 'Opened Traces';
+    static LIST_MARGIN = 2;
+    static LINE_HEIGHT = 16;
+
+    protected forceUpdateKey = false;
+
+    protected experimentSelectedEmitter = new Emitter<Experiment>();
+    experimentSelectedSignal = this.experimentSelectedEmitter.event;
+
+    protected availableOutputDescriptorsEmitter = new Emitter<Map<string, OutputDescriptor[]>>();
+    availableOutputDescriptorsDidChange = this.availableOutputDescriptorsEmitter.event;
+
+    @inject(TspClientProvider) protected readonly tspClientProvider!: TspClientProvider;
+    @inject(TraceExplorerTooltipWidget) protected readonly tooltipWidget!: TraceExplorerTooltipWidget;
+
+    protected readonly updateRequestEmitter = new Emitter<void>();
+    widgetWasUpdated = this.updateRequestEmitter.event;
+
+    sharingLink = '';
+    showShareDialog = false;
+    lastSelectedOutputIndex = -1;
+
+    protected _openedExperiments: Array<Experiment> = [];
+    get openedExperiments(): Array<Experiment> {
+        return this._openedExperiments;
+    }
+
+    protected _selectedExperimentIndex = 0;
+    get selectedExperimentIndex(): number {
+        return this._selectedExperimentIndex;
+    }
+    protected _availableOutputDescriptors: Map<string, OutputDescriptor[]> = new Map();
+    get availableOutputDescriptors(): Map<string, OutputDescriptor[]> {
+        return this._availableOutputDescriptors;
+    }
+    protected experimentManager!: ExperimentManager;
+    protected selectedExperiment: Experiment | undefined;
+
+    @postConstruct()
+    async init(): Promise<void> {
+        this.id = TraceExplorerOpenedTracesWidget.ID;
+        this.title.label = TraceExplorerOpenedTracesWidget.LABEL;
+
+        signalManager().on(Signals.EXPERIMENT_OPENED, ({ experiment }) => this.onExperimentOpened(experiment));
+        signalManager().on(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));
+        signalManager().on(Signals.EXPERIMENT_SELECTED, ({ experiment }) => this.onWidgetActivated(experiment));
+
+        this.experimentManager = this.tspClientProvider.getExperimentManager();
+        this.tspClientProvider.addTspClientChangeListener(() => {
+            this.experimentManager = this.tspClientProvider.getExperimentManager();
+        });
+
+        this.toDispose.pushAll([this.experimentSelectedEmitter, this.availableOutputDescriptorsEmitter]);
+
+        await this.initialize();
+        this.update();
+    }
+
+    dispose(): void {
+        super.dispose();
+        signalManager().off(Signals.EXPERIMENT_OPENED, ({ experiment }) => this.onExperimentOpened(experiment));
+        signalManager().off(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));
+        signalManager().off(Signals.EXPERIMENT_SELECTED, ({ experiment }) => this.onWidgetActivated(experiment));
+    }
+
+    async initialize(): Promise<void> {
+        await this.updateOpenedExperiments();
+        await this.updateAvailableAnalysis(undefined);
+    }
+
+    protected async onExperimentOpened(openedExperiment: Experiment): Promise<void> {
+        await this.updateOpenedExperiments();
+        await this.updateAvailableAnalysis(openedExperiment);
+    }
+
+    protected async onExperimentClosed(_closedExperiment: Experiment): Promise<void> {
+        this.tooltipWidget.tooltip = {};
+        await this.updateOpenedExperiments();
+        await this.updateAvailableAnalysis(undefined);
+    }
+
+    render(): React.ReactNode {
+        const totalHeight = this.getTotalHeight();
+        this.forceUpdateKey = !this.forceUpdateKey;
+        const key = Number(this.forceUpdateKey);
+        return (
+            <>
+                <ReactModal isOpen={this.showShareDialog} onRequestClose={this.handleShareModalClose}
+                    ariaHideApp={false} className='sharing-modal' overlayClassName='sharing-overlay'>
+                    {this.renderSharingModal()}
+                </ReactModal>
+                <div className='trace-explorer-opened'>
+                    <div className='trace-explorer-panel-content'
+                        onClick={this.updateOpenedExperiments}>
+                        <AutoSizer>
+                            {({ width }) =>
+                                <List
+                                    key={key}
+                                    height={totalHeight}
+                                    width={width}
+                                    rowCount={this._openedExperiments.length}
+                                    rowHeight={this.getRowHeight}
+                                    rowRenderer={this.renderExperimentRow}
+                                />}
+                        </AutoSizer>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    protected renderExperimentRow = (props: ListRowProps): React.ReactNode => this.doRenderExperimentRow(props);
+
+    /*
+        TODO: Implement better visualization of experiment, e.g. a tree
+        with experiment name as root and traces (name and path) as children
+     */
+    protected doRenderExperimentRow(props: ListRowProps): React.ReactNode {
+        const traceName = this._openedExperiments.length && props.index < this._openedExperiments.length
+            ? this._openedExperiments[props.index].name : '';
+        let traceContainerClassName = 'trace-list-container';
+        if (props.index === this._selectedExperimentIndex) {
+            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
+        }
+        return <div className={traceContainerClassName}
+            id={`${traceContainerClassName}-${props.index}`}
+            key={props.key}
+            style={props.style}
+            onClick={this.handleOnExperimentSelected}
+            data-id={`${props.index}`}>
+            <div className='trace-element-container'>
+                <div className='trace-element-info' >
+                    <h4 className='trace-element-name'>{traceName}</h4>
+                    {this.renderTracesForExperiment(props.index)}
+                </div>
+                {/* <div className='trace-element-options'>
+                    <button className='share-context-button' onClick={this.handleShareButtonClick.bind(this, props.index)}>
+                        <FontAwesomeIcon icon={faShareSquare} />
+                    </button>
+                </div> */}
+            </div>
+        </div>;
+    }
+
+    protected renderTracesForExperiment(index: number): React.ReactNode {
+        const tracePaths = this._openedExperiments[index].traces;
+        return (
+            <div className='trace-element-path-container'>
+                {tracePaths.map(trace => (
+                    <div className='trace-element-path child-element' id={trace.UUID} key={trace.UUID}>
+                        {` > ${trace.name}`}
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    protected getRowHeight = (index: Index | number): number => this.doGetRowHeight(index);
+
+    protected doGetRowHeight(index: Index | number): number {
+        const resolvedIndex = typeof index === 'object' ? index.index : index;
+        const experiment = this._openedExperiments[resolvedIndex];
+        let totalHeight = 0;
+        if (experiment.name) {
+            totalHeight += TraceExplorerOpenedTracesWidget.LINE_HEIGHT;
+        }
+        for (let i = 0; i < experiment.traces.length; i++) {
+            totalHeight += TraceExplorerOpenedTracesWidget.LINE_HEIGHT;
+        }
+        return totalHeight;
+    }
+
+    protected getTotalHeight(): number {
+        let totalHeight = 0;
+        for (let i = 0; i < this._openedExperiments.length; i++) {
+            totalHeight += this.getRowHeight(i);
+        }
+        return totalHeight;
+    }
+
+    protected renderSharingModal(): React.ReactNode {
+        if (this.sharingLink.length) {
+            return <div className='sharing-container'>
+                <div className='sharing-description'>
+                    {'Copy URL to share your trace context'}
+                </div>
+                <div className='sharing-link-info'>
+                    <div className='sharing-link'>
+                        <textarea rows={1} cols={this.sharingLink.length} readOnly={true} value={this.sharingLink} />
+                    </div>
+                    <div className='sharing-link-copy'>
+                        <button className='copy-link-button'>
+                            <FontAwesomeIcon icon={faCopy} />
+                        </button>
+                    </div>
+                </div>
+            </div>;
+        }
+        return <div style={{ color: 'white' }}>
+            {'Cannot share this trace'}
+        </div>;
+    }
+
+    protected updateOpenedExperiments = async (): Promise<void> => this.doUpdateOpenedExperiments();
+
+    protected async doUpdateOpenedExperiments(): Promise<void> {
+        this._openedExperiments = await this.experimentManager.getOpenedExperiments();
+        const selectedIndex = this._openedExperiments.findIndex(experiment => this.selectedExperiment &&
+            experiment.UUID === this.selectedExperiment.UUID);
+        this._selectedExperimentIndex = selectedIndex !== -1 ? selectedIndex : 0;
+        this.update();
+    }
+
+    protected handleShareButtonClick = (index: number): void => this.doHandleShareButtonClick(index);
+
+    protected doHandleShareButtonClick(index: number): void {
+        const traceToShare = this._openedExperiments[index];
+        this.sharingLink = 'https://localhost:3000/share/trace?' + traceToShare.UUID;
+        this.showShareDialog = true;
+        this.update();
+    }
+
+    protected handleOnExperimentSelected = (e: React.MouseEvent<HTMLDivElement>): void => this.doHandleOnExperimentSelected(e);
+
+    protected doHandleOnExperimentSelected(e: React.MouseEvent<HTMLDivElement>): void {
+        const index = Number(e.currentTarget.getAttribute('data-id'));
+        this.experimentSelectedEmitter.fire(this._openedExperiments[index]);
+        this.selectExperiment(index);
+    }
+
+    protected selectExperiment(index: number): void {
+        if (index >= 0 && index !== this._selectedExperimentIndex) {
+            this._selectedExperimentIndex = index;
+            this.lastSelectedOutputIndex = -1;
+            this.updateAvailableAnalysis(this._openedExperiments[index]);
+        }
+    }
+
+    protected updateAvailableAnalysis = async (experiment: Experiment | undefined): Promise<void> => this.doUpdateAvailableAnalysis(experiment);
+
+    protected async doUpdateAvailableAnalysis(experiment: Experiment | undefined): Promise<void> {
+        if (experiment) {
+            const outputs = await this.getOutputDescriptors(experiment);
+            this._availableOutputDescriptors.set(experiment.UUID, outputs);
+        } else {
+            if (this._openedExperiments.length) {
+                const outputs = await this.getOutputDescriptors(this._openedExperiments[0]);
+                this._availableOutputDescriptors.set(this._openedExperiments[0].UUID, outputs);
+            }
+        }
+        this.availableOutputDescriptorsEmitter.fire(this._availableOutputDescriptors);
+        this.update();
+    }
+
+    protected async getOutputDescriptors(experiment: Experiment): Promise<OutputDescriptor[]> {
+        const outputDescriptors: OutputDescriptor[] = [];
+        const descriptors = await this.experimentManager.getAvailableOutputs(experiment.UUID);
+        if (descriptors && descriptors.length) {
+            outputDescriptors.push(...descriptors);
+        }
+        return outputDescriptors;
+    }
+
+    onWidgetActivated(experiment: Experiment): void {
+        this.selectedExperiment = experiment;
+        const selectedIndex = this._openedExperiments.findIndex(openedExperiment => openedExperiment.UUID === experiment.UUID);
+        this.selectExperiment(selectedIndex);
+    }
+
+    protected handleShareModalClose = (): void => this.doHandleShareModalClose();
+
+    protected doHandleShareModalClose(): void {
+        this.showShareDialog = false;
+        this.sharingLink = '';
+        this.update();
+    }
+
+    protected onResize(msg: Widget.ResizeMessage): void {
+        super.onResize(msg);
+        this.update();
+    }
+
+    protected onUpdateRequest(msg: Message): void {
+        super.onUpdateRequest(msg);
+        this.updateRequestEmitter.fire();
+    }
+
+    protected async onAfterShow(msg: Message): Promise<void> {
+        super.onAfterShow(msg);
+        await this.updateOpenedExperiments();
+    }
+}

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
@@ -1,0 +1,36 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { ReactWidget } from '@theia/core/lib/browser';
+import * as React from 'react';
+import { CommandService } from '@theia/core';
+import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
+
+@injectable()
+export class TraceExplorerPlaceholderWidget extends ReactWidget {
+    static ID = 'trace-explorer-placeholder-widget';
+    static LABEL = 'Trace Exploerer Placeholder Widget';
+
+    @inject(CommandService) protected readonly commandService!: CommandService;
+
+    @postConstruct()
+    init(): void {
+        this.id = TraceExplorerPlaceholderWidget.ID;
+        this.title.label = TraceExplorerPlaceholderWidget.LABEL;
+        this.update();
+    }
+
+    render(): React.ReactNode {
+        return <div className='theia-navigator-container' tabIndex={0}>
+            <div className='center'>{'You have not yet opened a trace.'}</div>
+            <div className='open-workspace-button-container'>
+                <button className='theia-button open-workspace-button' title='Select a trace to open'
+                    onClick={this.handleOpenTrace}>{'Open Trace'}</button>
+            </div>
+        </div>;
+    }
+
+    protected handleOpenTrace = async (): Promise<void> => this.doHandleOpenTrace();
+
+    private async doHandleOpenTrace() {
+        this.commandService.executeCommand(OpenTraceCommand.id);
+    }
+}

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-tooltip-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-tooltip-widget.tsx
@@ -1,0 +1,123 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import { ReactWidget, Message } from '@theia/core/lib/browser';
+import * as React from 'react';
+import { EditorOpenerOptions, EditorManager } from '@theia/editor/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { Signals, signalManager } from '@trace-viewer/base/lib/signal-manager';
+
+@injectable()
+export class TraceExplorerTooltipWidget extends ReactWidget {
+    static ID = 'trace-explorer-tooltip-widget';
+    static LABEL = 'Time Graph Tooltip';
+
+    @inject(EditorManager) protected readonly editorManager!: EditorManager;
+
+    tooltip: { [key: string]: string } = {};
+
+    @postConstruct()
+    init(): void {
+        this.id = TraceExplorerTooltipWidget.ID;
+        this.title.label = TraceExplorerTooltipWidget.LABEL;
+        signalManager().on(Signals.TOOLTIP_UPDATED, ({ tooltip }) => this.onTooltip(tooltip));
+        this.update();
+    }
+
+    dispose(): void {
+        super.dispose();
+        signalManager().off(Signals.TOOLTIP_UPDATED, ({ tooltip }) => this.onTooltip(tooltip));
+    }
+
+    private renderTooltip() {
+        const tooltipArray: JSX.Element[] = [];
+        if (this.tooltip) {
+            const keys = Object.keys(this.tooltip);
+            keys.forEach(key => {
+                if (key === 'Source') {
+                    const sourceCodeInfo = this.tooltip[key];
+                    const matches = sourceCodeInfo.match('(.*):(\\d+)');
+                    let fileLocation;
+                    let line;
+                    if (matches && matches.length === 3) {
+                        fileLocation = matches[1];
+                        line = matches[2];
+                    }
+                    tooltipArray.push(<p className='source-code-tooltip'
+                        key={key}
+                        onClick={this.handleSourcecodeLookup}
+                        data-id={JSON.stringify({ fileLocation, line })}
+                    >{key + ': ' + sourceCodeInfo}</p>);
+                } else {
+                    tooltipArray.push(<p key={key}>{key + ': ' + this.tooltip[key]}</p>);
+                }
+            });
+        }
+
+        return (
+            <React.Fragment>
+                {tooltipArray.map(element => element)}
+            </React.Fragment>);
+    }
+
+    protected handleSourcecodeLookup = (e: React.MouseEvent<HTMLParagraphElement>): void => this.doHandleSourcecodeLookup(e);
+
+    private doHandleSourcecodeLookup(e: React.MouseEvent<HTMLParagraphElement>) {
+        const { fileLocation, line }: { fileLocation: string, line: string } = JSON.parse(`${e.currentTarget.getAttribute('data-id')}`);
+        if (fileLocation) {
+            const modeOpt: EditorOpenerOptions = {
+                mode: 'open'
+            };
+            let slectionOpt = {
+                selection: {
+                    start: {
+                        line: 0,
+                        character: 0
+                    },
+                    end: {
+                        line: 0,
+                        character: 0
+                    }
+                }
+            };
+            if (line) {
+                const lineNumber = parseInt(line);
+                slectionOpt = {
+                    selection: {
+                        start: {
+                            line: lineNumber,
+                            character: 0
+                        },
+                        end: {
+                            line: lineNumber,
+                            character: 0
+                        }
+                    }
+                };
+            }
+            const opts = {
+                ...modeOpt,
+                ...slectionOpt
+            };
+            this.editorManager.open(new URI(fileLocation), opts);
+        }
+    }
+
+    render(): React.ReactNode {
+        return (
+            <div className='trace-explorer-tooltip'>
+                <div className='trace-explorer-panel-content'>
+                    {this.renderTooltip()}
+                </div>
+            </div>
+        );
+    }
+
+    private onTooltip(tooltip: { [key: string]: string }) {
+        this.tooltip = tooltip;
+        this.update();
+    }
+
+    protected onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.update();
+    }
+}

--- a/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -1,419 +1,87 @@
-import { injectable, inject } from 'inversify';
-import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
-import * as React from 'react';
-import { List, ListRowProps } from 'react-virtualized';
-import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { /* faShareSquare, */ faCopy } from '@fortawesome/free-solid-svg-icons';
-import ReactModal from 'react-modal';
-import { Emitter } from '@theia/core';
-import { EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
-import URI from '@theia/core/lib/common/uri';
+import { injectable, inject, postConstruct, interfaces, Container } from 'inversify';
+import { TraceExplorerAnalysisWidget } from './trace-explorer-sub-widgets/trace-explorer-analysis-widget';
+import { ViewContainer, BaseWidget, Message, PanelLayout } from '@theia/core/lib/browser';
+import { TraceExplorerTooltipWidget } from './trace-explorer-sub-widgets/trace-explorer-tooltip-widget';
+import { TraceExplorerOpenedTracesWidget } from './trace-explorer-sub-widgets/trace-explorer-opened-traces-widget';
+import { TraceExplorerPlaceholderWidget } from './trace-explorer-sub-widgets/trace-explorer-placeholder-widget';
+import { OutputAddedSignalPayload } from './output-added-signal-payload';
+import { Event } from '@theia/core';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
-import { ExperimentManager } from '@trace-viewer/base/lib/experiment-manager';
-import { TspClientProvider } from '../tsp-client-provider';
-import { signalManager, Signals } from '@trace-viewer/base/lib/signal-manager';
-/* FIXME: This may cause Circular dependency between trace-viewer and trace-explorer-widget */
-import { TraceViewerWidget } from '../trace-viewer/trace-viewer';
-import { TraceViewerContribution } from '../trace-viewer/trace-viewer-contribution';
-
-export const TRACE_EXPLORER_ID = 'trace-explorer';
-export const TRACE_EXPLORER_LABEL = 'Trace Explorer';
-
-export class OutputAddedSignalPayload {
-    private outputDescriptor: OutputDescriptor;
-    private experiment: Experiment;
-
-    constructor(outputDescriptor: OutputDescriptor, trace: Experiment) {
-        this.outputDescriptor = outputDescriptor;
-        this.experiment = trace;
-    }
-
-    public getOutputDescriptor(): OutputDescriptor {
-        return this.outputDescriptor;
-    }
-
-    public getExperiment(): Experiment {
-        return this.experiment;
-    }
-}
 
 @injectable()
-export class TraceExplorerWidget extends ReactWidget {
-    @inject(TraceViewerContribution)
-    protected readonly traceViewerContribution!: TraceViewerContribution;
+export class TraceExplorerWidget extends BaseWidget {
+    static LABEL = 'Trace Explorer';
+    static ID = 'trace-explorer';
+    protected traceViewsContainer!: ViewContainer;
+    @inject(TraceExplorerAnalysisWidget) protected readonly analysisWidget!: TraceExplorerAnalysisWidget;
+    @inject(TraceExplorerOpenedTracesWidget) protected readonly openedTracesWidget!: TraceExplorerOpenedTracesWidget;
+    @inject(TraceExplorerTooltipWidget) protected readonly tooltipWidget!: TraceExplorerTooltipWidget;
+    @inject(TraceExplorerPlaceholderWidget) protected readonly placeholderWidget!: TraceExplorerPlaceholderWidget;
+    @inject(ViewContainer.Factory) protected readonly viewContainerFactory!: ViewContainer.Factory;
 
-    private OPENED_TRACE_TITLE = 'Opened Traces';
-    // private FILE_NAVIGATOR_TITLE: string = 'File navigator';
-    private ANALYSIS_TITLE = 'Available Analyses';
+    get outputAddedSignal(): Event<OutputAddedSignalPayload> {
+        return this.analysisWidget.outputAddedSignal;
+    }
 
-    private openedExperiments: Array<Experiment> = [];
-    private selectedExperimentIndex = 0;
-    private lastSelectedOutputIndex = -1;
-    private availableOutputDescriptors: Map<string, OutputDescriptor[]> = new Map();
+    get experimentSelectedSignal(): Event<Experiment> {
+        return this.openedTracesWidget.experimentSelectedSignal;
+    }
 
-    private showShareDialog = false;
-    private sharingLink = '';
+    onOpenedTracesWidgetActivated(experiment: Experiment): void {
+        return this.openedTracesWidget.onWidgetActivated(experiment);
+    }
 
-    private tooltip: { [key: string]: string } = {};
-    private selectedExperiment: Experiment | undefined;
-    private experimentManager: ExperimentManager;
+    static createWidget(parent: interfaces.Container): TraceExplorerWidget {
+        return TraceExplorerWidget.createContainer(parent).get(TraceExplorerWidget);
+    }
 
-    private static outputAddedEmitter = new Emitter<OutputAddedSignalPayload>();
-    public static outputAddedSignal = TraceExplorerWidget.outputAddedEmitter.event;
+    static createContainer(parent: interfaces.Container): Container {
+        const child = new Container({ defaultScope: 'Singleton' });
+        child.parent = parent;
+        child.bind(TraceExplorerAnalysisWidget).toSelf();
+        child.bind(TraceExplorerOpenedTracesWidget).toSelf();
+        child.bind(TraceExplorerPlaceholderWidget).toSelf();
+        child.bind(TraceExplorerTooltipWidget).toSelf();
+        child.bind(TraceExplorerWidget).toSelf().inSingletonScope();
+        return child;
+    }
 
-    private static experimentSelectedEmitter = new Emitter<Experiment>();
-    public static experimentSelectedSignal = TraceExplorerWidget.experimentSelectedEmitter.event;
-
-    constructor(
-        @inject(TspClientProvider) private tspClientProvider: TspClientProvider,
-        @inject(EditorManager) protected readonly editorManager: EditorManager
-    ) {
-        super();
-        this.id = TRACE_EXPLORER_ID;
-        this.title.label = TRACE_EXPLORER_LABEL;
-        this.title.caption = TRACE_EXPLORER_LABEL;
+    @postConstruct()
+    init(): void {
+        this.id = TraceExplorerWidget.ID;
+        this.title.label = TraceExplorerWidget.LABEL;
+        this.title.caption = TraceExplorerWidget.LABEL;
         this.title.iconClass = 'trace-explorer-tab-icon';
         this.title.closable = true;
-        this.experimentManager = this.tspClientProvider.getExperimentManager();
-        signalManager().on(Signals.EXPERIMENT_OPENED, ({ experiment }) => this.onExperimentOpened(experiment));
-        signalManager().on(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));
-        signalManager().on(Signals.EXPERIMENT_SELECTED, ({ experiment }) => this.onWidgetActivated(experiment));
-        signalManager().on(Signals.TOOLTIP_UPDATED, ({ tooltip }) => this.onTooltip(tooltip));
-        this.toDispose.push(TraceViewerWidget.widgetActivatedSignal(experiment => this.onWidgetActivated(experiment)));
-        this.initialize();
-
-        this.tspClientProvider.addTspClientChangeListener(tspClient => {
-            this.experimentManager = this.tspClientProvider.getExperimentManager();
+        this.toDispose.push(this.openedTracesWidget.widgetWasUpdated(() => this.update()));
+        this.traceViewsContainer = this.viewContainerFactory({
+            id: this.id
         });
-    }
-
-    dispose() {
-        super.dispose();
-        signalManager().off(Signals.EXPERIMENT_OPENED, ({ experiment }) => this.onExperimentOpened(experiment));
-        signalManager().off(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));
-        signalManager().off(Signals.EXPERIMENT_SELECTED, ({ experiment }) => this.onWidgetActivated(experiment));
-        signalManager().off(Signals.TOOLTIP_UPDATED, ({ tooltip }) => this.onTooltip(tooltip));
-    }
-
-    private onExperimentOpened(openedExperiment: Experiment) {
-        this.updateOpenedExperiments();
-        this.updateAvailableAnalysis(openedExperiment);
-    }
-
-    private onExperimentClosed(_closedExperiment: Experiment) {
-        this.tooltip = {};
-        this.updateOpenedExperiments();
-        this.updateAvailableAnalysis(undefined);
-    }
-
-    private onTooltip(tooltip: { [key: string]: string }) {
-        this.tooltip = tooltip;
+        this.traceViewsContainer.addWidget(this.openedTracesWidget);
+        this.traceViewsContainer.addWidget(this.analysisWidget);
+        this.traceViewsContainer.addWidget(this.tooltipWidget);
+        this.toDispose.push(this.traceViewsContainer);
+        const layout = this.layout = new PanelLayout();
+        layout.addWidget(this.placeholderWidget);
+        layout.addWidget(this.traceViewsContainer);
+        this.node.tabIndex = 0;
         this.update();
     }
 
-    async initialize(): Promise<void> {
-        this.updateOpenedExperiments();
-        this.updateAvailableAnalysis(undefined);
-    }
-
-    private async handleOpenTrace() {
-        this.traceViewerContribution.openDialog();
-    }
-
-    protected render(): React.ReactNode {
-        this.updateOpenedExperiments = this.updateOpenedExperiments.bind(this);
-        this.updateAvailableAnalysis = this.updateAvailableAnalysis.bind(this);
-        this.experimentRowRenderer = this.experimentRowRenderer.bind(this);
-        this.outputsRowRenderer = this.outputsRowRenderer.bind(this);
-        this.handleShareModalClose = this.handleShareModalClose.bind(this);
-        this.handleOpenTrace = this.handleOpenTrace.bind(this);
-
-        let outputsRowCount = 0;
-        if (this.openedExperiments.length) {
-            const outputs = this.availableOutputDescriptors.get(this.openedExperiments[this.selectedExperimentIndex].UUID);
-            if (outputs) {
-                outputsRowCount = outputs.length;
-            }
-
-            return <div className='trace-explorer-container'>
-                <ReactModal isOpen={this.showShareDialog} onRequestClose={this.handleShareModalClose}
-                    ariaHideApp={false} className='sharing-modal' overlayClassName='sharing-overlay'>
-                    {this.renderSharingModal()}
-                </ReactModal>
-                <div className='trace-explorer-opened'>
-                    <div className='trace-explorer-panel-title' onClick={this.updateOpenedExperiments}>
-                        {this.OPENED_TRACE_TITLE}
-                    </div>
-                    <div className='trace-explorer-panel-content'>
-                        <List
-                            height={300}
-                            width={300}
-                            rowCount={this.openedExperiments.length}
-                            rowHeight={50}
-                            rowRenderer={this.experimentRowRenderer} />
-                    </div>
-                </div>
-                <div className='trace-explorer-analysis'>
-                    <div className='trace-explorer-panel-title'>
-                        {this.ANALYSIS_TITLE}
-                    </div>
-                    <div className='trace-explorer-panel-content'>
-                        <List
-                            height={300}
-                            width={300}
-                            rowCount={outputsRowCount}
-                            rowHeight={50}
-                            rowRenderer={this.outputsRowRenderer} />
-                    </div>
-                </div>
-                <div className='trace-explorer-tooltip'>
-                    <div className='trace-explorer-panel-title'>
-                        {'Time Graph Tooltip'}
-                    </div>
-                    <div className='trace-explorer-panel-content'>
-                        {this.renderTooltip()}
-                    </div>
-                </div>
-            </div>;
-        }
-
-        return <div className='theia-navigator-container' tabIndex={0}>
-            <div className='center'>{'You have not yet opened a trace.'}</div>
-            <div className='open-workspace-button-container'>
-                <button className='theia-button open-workspace-button' title='Select a trace to open'
-                    onClick={this.handleOpenTrace}>{'Open Trace'}</button>
-            </div>
-        </div>;
-    }
-
-    private renderTooltip() {
-        this.handleSourcecodeLockup = this.handleSourcecodeLockup.bind(this);
-        const tooltipArray: JSX.Element[] = [];
-        if (this.tooltip) {
-            const keys = Object.keys(this.tooltip);
-            keys.forEach(key => {
-                if (key === 'Source') {
-                    const sourceCodeInfo = this.tooltip[key];
-                    const matches = sourceCodeInfo.match('(.*):(\\d+)');
-                    let fileLocation;
-                    let line;
-                    if (matches && matches.length === 3) {
-                        fileLocation = matches[1];
-                        line = matches[2];
-                    }
-                    tooltipArray.push(<p className='source-code-tooltip'
-                        key={key}
-                        onClick={this.handleSourcecodeLockup.bind(this, fileLocation, line)}>{key + ': ' + sourceCodeInfo}</p>);
-                } else {
-                    tooltipArray.push(<p key={key}>{key + ': ' + this.tooltip[key]}</p>);
-                }
-            });
-        }
-
-        return <React.Fragment>
-            {tooltipArray.map(element => element)}
-        </React.Fragment>;
-    }
-
-    private handleSourcecodeLockup(fileLocation: string | undefined, line: string | undefined) {
-        if (fileLocation) {
-            const modeOpt: EditorOpenerOptions = {
-                mode: 'open'
-            };
-            let slectionOpt = {
-                selection: {
-                    start: {
-                        line: 0,
-                        character: 0
-                    },
-                    end: {
-                        line: 0,
-                        character: 0
-                    }
-                }
-            };
-            if (line) {
-                const lineNumber = parseInt(line);
-                slectionOpt = {
-                    selection: {
-                        start: {
-                            line: lineNumber,
-                            character: 0
-                        },
-                        end: {
-                            line: lineNumber,
-                            character: 0
-                        }
-                    }
-                };
-            }
-            const opts = {
-                ...modeOpt,
-                ...slectionOpt
-            };
-            this.editorManager.open(new URI(fileLocation), opts);
-        }
-    }
-
-    private renderSharingModal() {
-        if (this.sharingLink.length) {
-            return <div className='sharing-container'>
-                <div className='sharing-description'>
-                    {'Copy URL to share your trace context'}
-                </div>
-                <div className='sharing-link-info'>
-                    <div className='sharing-link'>
-                        <textarea rows={1} cols={this.sharingLink.length} readOnly={true} value={this.sharingLink} />
-                    </div>
-                    <div className='sharing-link-copy'>
-                        <button className='copy-link-button'>
-                            <FontAwesomeIcon icon={faCopy} />
-                        </button>
-                    </div>
-                </div>
-            </div>;
-        }
-        return <div style={{ color: 'white' }}>
-            {'Cannot share this trace'}
-        </div>;
-    }
-
-    private experimentRowRenderer(props: ListRowProps): React.ReactNode {
-        let traceName = '';
-        let tracePath = '';
-        if (this.openedExperiments && this.openedExperiments.length && props.index < this.openedExperiments.length) {
-            traceName = this.openedExperiments[props.index].name;
-            // tracePath = this.openedTraces[props.index].path;
-            /*
-                TODO: Implement better visualization of experiment, e.g. a tree
-                with experiment name as root and traces (name and path) as children
-             */
-            let prefix = '> ';
-            for (let i = 0; i < this.openedExperiments[props.index].traces.length; i++) {
-                // tracePath = tracePath.concat(prefix).concat(this.openedExperiments[props.index].traces[i].path);
-                tracePath = tracePath.concat(prefix).concat(this.openedExperiments[props.index].traces[i].name);
-                prefix = '\n> ';
-            }
-        }
-        let traceContainerClassName = 'trace-element-container';
-        if (props.index === this.selectedExperimentIndex) {
-            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
-        }
-        this.handleShareButtonClick = this.handleShareButtonClick.bind(this);
-        return <div className='trace-list-container' key={props.key} style={props.style}>
-            <div className={traceContainerClassName}>
-                <div className='trace-element-info' onClick={this.onExperimentSelected.bind(this, props.index)}>
-                    <div className='trace-element-name'>
-                        {traceName}
-                    </div>
-                    <div className='trace-element-path'>
-                        {tracePath}
-                    </div>
-                </div>
-                {/* <div className='trace-element-options'>
-                    <button className='share-context-button' onClick={this.handleShareButtonClick.bind(this, props.index)}>
-                        <FontAwesomeIcon icon={faShareSquare} />
-                    </button>
-                </div> */}
-            </div>
-        </div>;
-    }
-
-    private onWidgetActivated(experiment: Experiment) {
-        this.selectedExperiment = experiment;
-        const selectedIndex = this.openedExperiments.findIndex(openedExperiment => openedExperiment.UUID === experiment.UUID);
-        this.selectExperiment(selectedIndex);
-    }
-
-    private onExperimentSelected(index: number) {
-        TraceExplorerWidget.experimentSelectedEmitter.fire(this.openedExperiments[index]);
-        this.selectExperiment(index);
-    }
-
-    private selectExperiment(index: number) {
-        if (index >= 0 && index !== this.selectedExperimentIndex) {
-            this.selectedExperimentIndex = index;
-            this.lastSelectedOutputIndex = -1;
-            this.updateAvailableAnalysis(this.openedExperiments[index]);
-        }
-    }
-
-    private handleShareButtonClick(index: number) {
-        const traceToShare = this.openedExperiments[index];
-        this.sharingLink = 'https://localhost:3000/share/trace?' + traceToShare.UUID;
-        this.showShareDialog = true;
-        this.update();
-    }
-
-    private handleShareModalClose() {
-        this.showShareDialog = false;
-        this.sharingLink = '';
-        this.update();
-    }
-
-    private outputsRowRenderer(props: ListRowProps): React.ReactNode {
-        let outputName = '';
-        let outputDescription = '';
-        const selectedTrace = this.openedExperiments[this.selectedExperimentIndex];
-        if (selectedTrace) {
-            const outputDescriptors = this.availableOutputDescriptors.get(selectedTrace.UUID);
-            if (outputDescriptors && outputDescriptors.length && props.index < outputDescriptors.length) {
-                outputName = outputDescriptors[props.index].name;
-                outputDescription = outputDescriptors[props.index].description;
-            }
-        }
-        let traceContainerClassName = 'outputs-list-container';
-        if (props.index === this.lastSelectedOutputIndex) {
-            traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
-        }
-        return <div className={traceContainerClassName} key={props.key} style={props.style} onClick={this.outputClicked.bind(this, props.index)}>
-            <div className='outputs-element-name'>
-                {outputName}
-            </div>
-            <div className='outputs-element-description'>
-                {outputDescription}
-            </div>
-        </div>;
-    }
-
-    private outputClicked(index: number) {
-        this.lastSelectedOutputIndex = index;
-        const trace = this.openedExperiments[this.selectedExperimentIndex];
-        const outputs = this.availableOutputDescriptors.get(trace.UUID);
-        if (outputs) {
-            TraceExplorerWidget.outputAddedEmitter.fire(new OutputAddedSignalPayload(outputs[index], trace));
-        }
-        this.update();
-    }
-
-    private async updateOpenedExperiments() {
-        this.openedExperiments = await this.experimentManager.getOpenedExperiments();
-        const selectedIndex = this.openedExperiments.findIndex(experiment => this.selectedExperiment &&
-            experiment.UUID === this.selectedExperiment.UUID);
-        this.selectedExperimentIndex = selectedIndex !== -1 ? selectedIndex : 0;
-        this.update();
-    }
-
-    private async updateAvailableAnalysis(experiment: Experiment | undefined) {
-        if (experiment) {
-            const outputs = await this.getOutputDescriptors(experiment);
-            this.availableOutputDescriptors.set(experiment.UUID, outputs);
+    protected onUpdateRequest(msg: Message): void {
+        super.onUpdateRequest(msg);
+        const { openedExperiments } = this.openedTracesWidget;
+        if (openedExperiments.length) {
+            this.traceViewsContainer.show();
+            this.placeholderWidget.hide();
         } else {
-            if (this.openedExperiments.length) {
-                const outputs = await this.getOutputDescriptors(this.openedExperiments[0]);
-                this.availableOutputDescriptors.set(this.openedExperiments[0].UUID, outputs);
-            }
+            this.traceViewsContainer.hide();
+            this.placeholderWidget.show();
         }
-        this.update();
     }
 
-    private async getOutputDescriptors(experiment: Experiment): Promise<OutputDescriptor[]> {
-        const outputDescriptors: OutputDescriptor[] = [];
-        const descriptors = await this.experimentManager.getAvailableOutputs(experiment.UUID);
-        if (descriptors && descriptors.length) {
-            outputDescriptors.push(...descriptors);
-        }
-        return outputDescriptors;
+    protected onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.node.focus();
     }
 }

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -1,0 +1,6 @@
+import { Command } from '@theia/core';
+
+export const OpenTraceCommand: Command = {
+    id: 'open-trace',
+    label: 'Open Trace'
+};

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -1,22 +1,11 @@
 import { injectable, inject } from 'inversify';
-import { Command, CommandRegistry, CommandContribution } from '@theia/core';
+import { CommandRegistry, CommandContribution } from '@theia/core';
 import { WidgetOpenHandler } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-
-export namespace TraceViewerCommands {
-    export const OPEN: Command = {
-        id: 'trace:open',
-        label: 'Open Trace'
-    };
-}
-
-const OpenTraceCommand: Command = {
-    id: 'open-trace',
-    label: 'Open Trace'
-};
+import { OpenTraceCommand } from './trace-viewer-commands';
 
 @injectable()
 export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget> implements CommandContribution {
@@ -27,7 +16,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     protected readonly workspaceService!: WorkspaceService;
 
     readonly id = TraceViewerWidget.ID;
-    readonly label = TraceViewerCommands.OPEN.label;
+    readonly label = 'Trace Viewer';
 
     protected createWidgetOptions(uri: URI): TraceViewerWidgetOptions {
         return {
@@ -49,7 +38,6 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     }
 
     registerCommands(registry: CommandRegistry): void {
-        registry.registerCommand(TraceViewerCommands.OPEN);
         registry.registerCommand(OpenTraceCommand, {
             execute: () => {
                 this.openDialog();

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -5,22 +5,21 @@ import { TraceViewerContribution } from './trace-viewer-contribution';
 import { TraceViewerEnvironment } from '../../common/trace-viewer-environment';
 import { TraceServerUrlProvider } from '../../common/trace-server-url-provider';
 import { CommandContribution } from '@theia/core/lib/common';
-
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-balham-dark.css';
 import 'ag-grid-community/dist/styles/ag-theme-balham.css';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-contribution';
-import { TRACE_EXPLORER_ID, TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
+import { TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TspClientProvider } from '../tsp-client-provider';
 import { TheiaMessageManager } from '../theia-message-manager';
 import { TraceServerConnectionStatusService, TraceServerConnectionStatusContribution } from '../../browser/trace-server-status';
 import { TraceServerUrlProviderImpl } from '../trace-server-url-provider-frontend-impl';
 import { bindTraceServerPreferences } from '../trace-server-bindings';
 import { TraceServerConfigService, traceServerPath } from '../../common/trace-server-config';
-export default new ContainerModule(bind => {
 
+export default new ContainerModule(bind => {
     bind(TraceViewerEnvironment).toSelf().inRequestScope();
     bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceServerUrlProviderImpl);
@@ -45,25 +44,21 @@ export default new ContainerModule(bind => {
     );
 
     bindViewContribution(bind, TraceExplorerContribution);
-    bind(TraceExplorerWidget).toSelf();
     bind(FrontendApplicationContribution).toService(TraceExplorerContribution);
     bind(WidgetFactory).toDynamicValue(context => ({
-        id: TRACE_EXPLORER_ID,
-        createWidget: () => context.container.get<TraceExplorerWidget>(TraceExplorerWidget)
-    }));
+        id: TraceExplorerWidget.ID,
+        createWidget: () => TraceExplorerWidget.createWidget(context.container)
+    })).inSingletonScope();
 
     bind(TraceServerConfigService).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
         return connection.createProxy<TraceServerConfigService>(traceServerPath);
     }).inSingletonScope();
-
     bind(TraceServerConnectionStatusService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusService);
     bind(TraceServerConnectionStatusContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceServerConnectionStatusContribution);
-
     bindTraceServerPreferences(bind);
-
     // bindViewContribution(bind, TracePropertiesContribution);
     // bind(TracePropertiesWidget).toSelf();
     // bind(WidgetFactory).toDynamicValue(context => ({

--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -1,23 +1,23 @@
-import { MessageService, Path } from '@theia/core';
+import { DisposableCollection, MessageService, Path } from '@theia/core';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common/filesystem';
-import { ApplicationShell, Message, StatusBar } from '@theia/core/lib/browser';
+import { ApplicationShell, Message, StatusBar, WidgetManager } from '@theia/core/lib/browser';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import * as React from 'react';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { Trace } from 'tsp-typescript-client/lib/models/trace';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider';
 import { TraceManager } from '@trace-viewer/base/lib/trace-manager';
-import { Emitter } from '@theia/core';
 import { ExperimentManager } from '@trace-viewer/base/lib/experiment-manager';
-import { OutputAddedSignalPayload, TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 import { TraceContextComponent } from '@trace-viewer/react-components/lib/components/trace-context-component';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import URI from '@theia/core/lib/common/uri';
 import { TheiaMessageManager } from '../theia-message-manager';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { signalManager } from '@trace-viewer/base/lib/signal-manager';
+import { OutputAddedSignalPayload } from '../trace-explorer/output-added-signal-payload';
+import { TraceExplorerWidget } from '../trace-explorer/trace-explorer-widget';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -29,39 +29,37 @@ export class TraceViewerWidget extends ReactWidget {
     static ID = 'trace-viewer';
     static LABEL = 'Trace Viewer';
 
-    protected readonly uri: Path;
-    private openedExperiment: Experiment | undefined;
-    private outputDescriptors: OutputDescriptor[] = [];
-    private tspClient: TspClient;
-    private traceManager: TraceManager;
-    private experimentManager: ExperimentManager;
-    private backgroundTheme: string;
+    protected uri: Path;
+    protected openedExperiment: Experiment | undefined;
+    protected outputDescriptors: OutputDescriptor[] = [];
+    protected tspClient: TspClient;
+    protected traceManager: TraceManager;
+    protected experimentManager: ExperimentManager;
+    protected backgroundTheme: string;
 
-    private resizeHandlers: (() => void)[] = [];
-    private readonly addResizeHandler = (h: () => void) => {
+    protected resizeHandlers: (() => void)[] = [];
+    protected readonly addResizeHandler = (h: () => void): void => {
         this.resizeHandlers.push(h);
     };
 
-    private static widgetActivatedEmitter = new Emitter<Experiment>();
-    public static widgetActivatedSignal = TraceViewerWidget.widgetActivatedEmitter.event;
+    protected explorerWidget: TraceExplorerWidget;
 
-    constructor(
-        @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions,
-        @inject(TspClientProvider) private tspClientProvider: TspClientProvider,
-        @inject(StatusBar) private statusBar: StatusBar,
-        @inject(FileSystem) private readonly fileSystem: FileSystem,
-        @inject(ApplicationShell) protected readonly shell: ApplicationShell,
-        @inject(TheiaMessageManager) private readonly _signalHandler: TheiaMessageManager,
-        @inject(MessageService) protected readonly messageService: MessageService
-    ) {
-        super();
+    @inject(WidgetManager) protected readonly widgetManager: WidgetManager;
+    @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions;
+    @inject(TspClientProvider) protected tspClientProvider: TspClientProvider;
+    @inject(StatusBar) protected statusBar: StatusBar;
+    @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+    @inject(TheiaMessageManager) protected readonly _signalHandler: TheiaMessageManager;
+    @inject(MessageService) protected readonly messageService: MessageService;
+
+    @postConstruct()
+    async init(): Promise<void> {
         this.uri = new Path(this.options.traceURI);
         this.id = 'theia-traceOpen';
         this.title.label = 'Trace: ' + this.uri.base;
         this.title.closable = true;
         this.addClass('theia-trace-open');
-        this.toDispose.push(TraceExplorerWidget.outputAddedSignal(output => this.onOutputAdded(output)));
-        this.toDispose.push(TraceExplorerWidget.experimentSelectedSignal(experiment => this.onExperimentSelected(experiment)));
         this.backgroundTheme = ThemeService.get().getCurrentTheme().type;
         ThemeService.get().onThemeChange(() => this.updateBackgroundTheme());
         this.initialize();
@@ -73,9 +71,28 @@ export class TraceViewerWidget extends ReactWidget {
             this.traceManager = this.tspClientProvider.getTraceManager();
             this.experimentManager = this.experimentManager = this.tspClientProvider.getExperimentManager();
         });
+        this.toDispose.push(this.widgetManager.onDidCreateWidget(({ widget }) => {
+            if (widget instanceof TraceExplorerWidget) {
+                this.explorerWidget = widget;
+                this.subscribeToExplorerEvents();
+            }
+        }));
+        this.explorerWidget = await this.widgetManager.getOrCreateWidget(TraceExplorerWidget.ID);
+        this.subscribeToExplorerEvents();
+        this.toDispose.push(this.toDisposeOnNewExplorer);
+        // Make node focusable so it can achieve focus on activate (avoid warning);
+        this.node.tabIndex = 0;
     }
 
-    private updateBackgroundTheme() {
+    protected readonly toDisposeOnNewExplorer = new DisposableCollection();
+
+    protected subscribeToExplorerEvents(): void {
+        this.toDisposeOnNewExplorer.dispose();
+        this.toDisposeOnNewExplorer.push(this.explorerWidget.outputAddedSignal(output => this.onOutputAdded(output)));
+        this.toDisposeOnNewExplorer.push(this.explorerWidget.experimentSelectedSignal(experiment => this.onExperimentSelected(experiment)));
+    }
+
+    protected updateBackgroundTheme(): void {
         const currentThemeType = ThemeService.get().getCurrentTheme().type;
         signalManager().fireThemeChangedSignal(currentThemeType);
     }
@@ -85,20 +102,20 @@ export class TraceViewerWidget extends ReactWidget {
          * TODO: use backend service to find traces
          */
 
-         const isCancelled = { value: false };
+        const isCancelled = { value: false };
 
         // This will show a progress dialog with "Cancel" option
         this.messageService.showProgress({
             text: 'Open traces'
         },
-        () => {
-            isCancelled.value = true;
-        })
-        .then(async progress => {
-            try {
-                const tracesArray = new Array<Path>();
-                const fileStat = await this.fileSystem.getFileStat(this.uri.toString());
-                progress.report({message: 'Finding traces ', work: {done: 10, total: 100}});
+            () => {
+                isCancelled.value = true;
+            })
+            .then(async progress => {
+                try {
+                    const tracesArray = new Array<Path>();
+                    const fileStat = await this.fileSystem.getFileStat(this.uri.toString());
+                    progress.report({ message: 'Finding traces ', work: { done: 10, total: 100 } });
                     if (fileStat) {
                         if (fileStat.isDirectory) {
                             // Find recursivly CTF traces
@@ -111,12 +128,12 @@ export class TraceViewerWidget extends ReactWidget {
 
                     const traces = new Array<Trace>();
                     if (isCancelled.value) {
-                        progress.report({message: 'Complete', work: {done: 100, total: 100}});
+                        progress.report({ message: 'Complete', work: { done: 100, total: 100 } });
                         this.dispose();
                         return;
                     }
 
-                    progress.report({message: 'Opening traces', work: {done: 30, total: 100}});
+                    progress.report({ message: 'Opening traces', work: { done: 30, total: 100 } });
                     for (let i = 0; i < tracesArray.length; i++) {
                         if (isCancelled.value) {
                             break;
@@ -129,11 +146,11 @@ export class TraceViewerWidget extends ReactWidget {
 
                     if (isCancelled.value) {
                         // Rollback traces
-                        progress.report({message: 'Rolling back traces', work: {done: 50, total: 100}});
+                        progress.report({ message: 'Rolling back traces', work: { done: 50, total: 100 } });
                         for (let i = 0; i < traces.length; i++) {
                             await this.traceManager.closeTrace(traces[i].UUID);
                         }
-                        progress.report({message: 'Complete', work: {done: 100, total: 100}});
+                        progress.report({ message: 'Complete', work: { done: 100, total: 100 } });
                         this.dispose();
                         return;
                     }
@@ -145,7 +162,7 @@ export class TraceViewerWidget extends ReactWidget {
                         this.id = experiment.UUID;
 
                         if (this.isVisible) {
-                            TraceViewerWidget.widgetActivatedEmitter.fire(experiment);
+                            this.explorerWidget.onOpenedTracesWidgetActivated(experiment);
                         }
                     }
 
@@ -154,9 +171,9 @@ export class TraceViewerWidget extends ReactWidget {
                     console.log(e);
                     this.dispose();
                 }
-            progress.report({message: 'Complete', work: {done: 100, total: 100}});
-            progress.cancel();
-        });
+                progress.report({ message: 'Complete', work: { done: 100, total: 100 } });
+                progress.cancel();
+            });
     }
 
     onCloseRequest(msg: Message): void {
@@ -171,15 +188,16 @@ export class TraceViewerWidget extends ReactWidget {
     onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         if (this.openedExperiment) {
-            TraceViewerWidget.widgetActivatedEmitter.fire(this.openedExperiment);
+            this.explorerWidget.onOpenedTracesWidgetActivated(this.openedExperiment);
         }
     }
 
     onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.openedExperiment) {
-            TraceViewerWidget.widgetActivatedEmitter.fire(this.openedExperiment);
+            this.explorerWidget.onOpenedTracesWidgetActivated(this.openedExperiment);
         }
+        this.node.focus();
     }
 
     protected onResize(): void {
@@ -199,7 +217,7 @@ export class TraceViewerWidget extends ReactWidget {
         </div>;
     }
 
-    private onOutputAdded(payload: OutputAddedSignalPayload) {
+    protected onOutputAdded(payload: OutputAddedSignalPayload): void {
         if (this.openedExperiment && payload.getExperiment().UUID === this.openedExperiment.UUID) {
             const exist = this.outputDescriptors.find(output => output.id === payload.getOutputDescriptor().id);
             if (!exist) {
@@ -209,13 +227,13 @@ export class TraceViewerWidget extends ReactWidget {
         }
     }
 
-    private onOutputRemoved(outputId: string) {
+    protected onOutputRemoved(outputId: string): void {
         const outputToKeep = this.outputDescriptors.filter(output => output.id !== outputId);
         this.outputDescriptors = outputToKeep;
         this.update();
     }
 
-    private onExperimentSelected(experiment: Experiment) {
+    protected onExperimentSelected(experiment: Experiment): void {
         if (this.openedExperiment && this.openedExperiment.UUID === experiment.UUID) {
             this.shell.activateWidget(this.openedExperiment.UUID);
         }
@@ -224,7 +242,7 @@ export class TraceViewerWidget extends ReactWidget {
     /*
      * TODO: use backend service to find traces
      */
-    private async findTraces(rootStat: FileStat | undefined, traces: Array<Path>, isCancelled: { value: boolean; }) {
+    protected async findTraces(rootStat: FileStat | undefined, traces: Array<Path>, isCancelled: { value: boolean; }): Promise<void> {
         /**
          * If single file selection then return single trace in traces, if directory then find
          * recoursivly CTF traces in starting from root directory.
@@ -252,7 +270,7 @@ export class TraceViewerWidget extends ReactWidget {
             }
         }
     }
-    private isCtf(stat: FileStat): boolean {
+    protected isCtf(stat: FileStat): boolean {
         if (stat.children) {
             for (let i = 0; i < stat.children.length; i++) {
                 const path = new Path(stat.children[i].uri);


### PR DESCRIPTION
This MR applies several frontend fixes to the Trace Explorer Widget including:
- Wrap each 'sub widget' inside a panel layout to allow for view flexibility, drag/drop, expand/collapse, resize
- Address explorer-widget responsiveness, rows now adjust according to widget width (partially addresses #30)
- Add on-hover behavior to lists, and change to 'pointer' cursor
- Fix focus timeout issue when Trace Viewer widgets are activated, addresses #182 
- Fix double scrollbar from appearing in lists
- Fix some circular dependency issues
- Minor CSS fixes for consistency inside widget with Theia
- Refactoring of injection to use parameter style with postConstructor vs. constructor for extensibility, adjust `.bind` calls to Theia arrow function style
- Fixed duplicate registration of Open Trace command handler for file dialog and update command label to address #223 

Note that this is quite a large diff but most of the changes are due to copy/pasting into sub components and classes. I have not introduced any new functionality or removed existing functionality. Please verify for regressions.

Screenshot:

![dynamic_rows](https://user-images.githubusercontent.com/62660714/105244960-dd0e5e00-5b36-11eb-8588-4a8e98c8f116.gif)
