### PR TITLE
Use directory chooser only for open trace dialog

### DIFF
--- a/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -38,8 +38,9 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     public async openDialog(): Promise<void> {
         const props: OpenFileDialogProps = {
             title: 'Open Trace',
+            // Only support selecting folders, both folders and file doesn't work in Electron (issue #227)
             canSelectFolders: true,
-            canSelectFiles: true,
+            canSelectFiles: false
         };
         const root = this.workspaceService.tryGetRoots()[0];
         const fileURI = await this.fileDialogService.showOpenDialog(props, root);


### PR DESCRIPTION
Electron doesn't support opening a file dialog that allows selecting a
single file or a directory. This patch changes the implementation to
allow only the selection of directories. With this change a user can
select a directory that is a single CTF trace or a directory that
contains multiple CTF traces to be opened in the trace viewer after
clicking on the "Open Trace" button in the Trace Explorer as well as the
"Open Trace" command from the command palette (CTRL+SHIFT+P).

Traces that are a single file, cannot be opened from there but can be
opened using the context sensitive menu "Open With -> Trace Viewer"
from the regular file explorer of the application.

fixes #227

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>