### PR TITLE
Pending Message on Server Start/Stop

### DIFF
--- a/viewer-prototype/src/node/trace-server-service.ts
+++ b/viewer-prototype/src/node/trace-server-service.ts
@@ -4,11 +4,31 @@ import { TraceServerConfigService } from '../common/trace-server-config';
 @injectable()
 export class TraceServerServiceImpl implements TraceServerConfigService {
 
-    async startTraceServer(path: string | undefined, port: number | undefined): Promise<void> {
-        spawn(`${path}`, ['-vmargs', `-Dtraceserver.port=${port}`]);
+    startTraceServer(path: string | undefined, port: number | undefined): Promise<void> {
+        const server = spawn(`${path}`, ['-vmargs', `-Dtraceserver.port=${port}`]);
+        return new Promise<void>((resolve, reject) => {
+            // If the server provides output on any channel before it exits, consider that a success.
+            // That doesn't mean that the server has really started. On the frontend, the `TraceServerConnectionStatusService`
+            // will ping the port until it receives a response, which is the official measure of success.
+            server.stdout.on('data', () => resolve());
+            server.stderr.on('data', () => resolve());
+            // If the server exits or errors before it outputs, consider it a failure.
+            server.on('exit', code => reject(code));
+            server.on('error', error => reject(error));
+        })
+            .finally(() => { server.removeAllListeners(); });
     }
 
-    async stopTraceServer(port: number | undefined): Promise<void> {
-        exec(`kill -9 $(lsof -t -i:${port} -sTCP:LISTEN)`);  // FIXME: Better approach to kill the server at a given port
+    stopTraceServer(port: number | undefined): Promise<void> {
+        const terminator = exec(`kill -9 $(lsof -t -i:${port} -sTCP:LISTEN)`);  // FIXME: Better approach to kill the server at a given port
+        return new Promise((resolve, reject) => {
+            terminator.on('exit', code => {
+                if (code === 0 || code === 1) {
+                    resolve();
+                } else {
+                    reject(code);
+                }
+            });
+        });
     }
 }


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

This PR adds a temporary status message when the user gestures to start or stop the trace server.

To test:
1. Point your trace viewer executable and port preferences to good locations
2. Click `Start trace server` in the bottom left status bar.
3. See a message that indicates that server is starting.
4. ... wait < 10 seconds
5. See a change indicating that the server has started
6. Kill the server, see the same message

## Unhappy paths:
1. Point your preferences to a bad location (e.g. non-existent file, occupied port)
2. Try to start server
3. In <= 10 seconds you should see a failure message, and the display should revert to the previous state.

There is substantial overlap with #226, which supplies more exact error handling.