### PR TITLE
Decouple delete experiments from trace-viewer

### DIFF
--- a/packages/base/src/experiment-manager.ts
+++ b/packages/base/src/experiment-manager.ts
@@ -19,7 +19,7 @@ export class ExperimentManager {
     ) {
         this.fTspClient = tspClient;
         this.fTraceManager = traceManager;
-        signalManager().on(Signals.EXPERIMENT_CLOSED, ({experiment}) => this.onExperimentClosed(experiment));
+        signalManager().on(Signals.EXPERIMENT_CLOSED, ({ experiment }) => this.onExperimentClosed(experiment));
     }
 
     /**
@@ -98,7 +98,7 @@ export class ExperimentManager {
         const experiment = experimentResponse.getModel();
         if (experimentResponse.isOk() && experiment) {
             this.addExperiment(experiment);
-            signalManager().emit(Signals.EXPERIMENT_OPENED, {experiment: experiment});
+            signalManager().emit(Signals.EXPERIMENT_OPENED, { experiment: experiment });
             return experiment;
         }
         // TODO Handle any other experiment open errors
@@ -134,7 +134,7 @@ export class ExperimentManager {
             await this.fTspClient.deleteExperiment(experimentUUID);
             const deletedExperiment = this.removeExperiment(experimentUUID);
             if (deletedExperiment) {
-                signalManager().emit(Signals.EXPERIMENT_CLOSED, {experiment: deletedExperiment});
+                signalManager().emit(Signals.EXPERIMENT_CLOSED, { experiment: deletedExperiment });
             }
         }
     }
@@ -150,8 +150,11 @@ export class ExperimentManager {
         }
     }
 
-    private addExperiment(experiment: Experiment) {
+    public addExperiment(experiment: Experiment): void {
         this.fOpenExperiments.set(experiment.UUID, experiment);
+        experiment.traces.forEach(trace => {
+            this.fTraceManager.addTrace(trace);
+        });
     }
 
     private removeExperiment(experimentUUID: string): Experiment | undefined {
@@ -160,4 +163,3 @@ export class ExperimentManager {
         return deletedExperiment;
     }
 }
-

--- a/packages/base/src/signal-manager.ts
+++ b/packages/base/src/signal-manager.ts
@@ -5,6 +5,7 @@ export declare interface SignalManager {
     fireTooltipSignal(tooltip: { [key: string]: string }): void;
     fireThemeChangedSignal(theme: string): void;
     fireSelectionChangedSignal(payload: { [key: string]: string }): void;
+    fireCloseTraceViewerTabSignal(traceUUID: string): void;
 
 }
 
@@ -16,7 +17,8 @@ export const Signals = {
     EXPERIMENT_SELECTED: 'experiment selected',
     TOOLTIP_UPDATED: 'tooltip updated',
     THEME_CHANGED: 'theme changed',
-    SELECTION_CHANGED: 'selection changed'
+    SELECTION_CHANGED: 'selection changed',
+    TRACEVIEWER_CLOSED: 'tab closed'
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
@@ -31,6 +33,10 @@ export class SignalManager extends EventEmitter implements SignalManager {
 
     fireSelectionChangedSignal(payload: { [key: string]: string; }): void {
         this.emit(Signals.SELECTION_CHANGED, { payload });
+    }
+
+    fireCloseTraceViewerTabSignal(traceUUID: string): void {
+        this.emit(Signals.TRACEVIEWER_CLOSED, traceUUID);
     }
 
 }

--- a/packages/base/src/trace-manager.ts
+++ b/packages/base/src/trace-manager.ts
@@ -131,7 +131,7 @@ export class TraceManager {
         }
     }
 
-    private addTrace(trace: Trace) {
+    public addTrace(trace: Trace) {
         this.fOpenTraces.set(trace.UUID, trace);
     }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
@@ -1,0 +1,21 @@
+import { Command, MenuPath } from '@theia/core';
+
+export namespace TraceExplorerMenus {
+    export const PREFERENCE_EDITOR_CONTEXT_MENU: MenuPath = ['trace-explorer-opened-traces-context-menu'];
+}
+export namespace TraceExplorerCommands {
+    export const OPEN_TRACE: Command = {
+        id: 'trace-explorer:open-trace',
+        label: 'Open Trace'
+    };
+
+    export const CLOSE_TRACE: Command = {
+        id: 'trace-explorer:close-trace',
+        label: 'Close Trace'
+    };
+
+    export const DELETE_TRACE: Command = {
+        id: 'trace-explorer:delete-trace',
+        label: 'Delete Trace'
+    };
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -2,6 +2,8 @@ import { injectable } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { TraceExplorerWidget, } from './trace-explorer-widget';
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
+import { MenuModelRegistry, CommandRegistry } from '@theia/core';
+import { TraceExplorerCommands, TraceExplorerMenus } from './trace-explorer-commands';
 
 @injectable()
 export class TraceExplorerContribution extends AbstractViewContribution<TraceExplorerWidget> implements FrontendApplicationContribution {
@@ -16,8 +18,51 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
         });
     }
 
-    initializeLayout(_app: FrontendApplication): void {
-        this.openView({ activate: false });
+    async initializeLayout(_app: FrontendApplication): Promise<void> {
+        await this.openView({ activate: false });
     }
 
+    registerMenus(menus: MenuModelRegistry): void {
+        super.registerMenus(menus);
+        menus.registerMenuAction(TraceExplorerMenus.PREFERENCE_EDITOR_CONTEXT_MENU, {
+            commandId: TraceExplorerCommands.OPEN_TRACE.id,
+            label: TraceExplorerCommands.OPEN_TRACE.label,
+            order: 'a'
+        });
+
+        menus.registerMenuAction(TraceExplorerMenus.PREFERENCE_EDITOR_CONTEXT_MENU, {
+            commandId: TraceExplorerCommands.CLOSE_TRACE.id,
+            label: TraceExplorerCommands.CLOSE_TRACE.label,
+            order: 'b'
+        });
+
+        menus.registerMenuAction(TraceExplorerMenus.PREFERENCE_EDITOR_CONTEXT_MENU, {
+            commandId: TraceExplorerCommands.DELETE_TRACE.id,
+            label: TraceExplorerCommands.DELETE_TRACE.label,
+            order: 'c'
+        });
+    }
+
+    async registerCommands(registry: CommandRegistry): Promise<void> {
+        super.registerCommands(registry);
+        const explorerWidget = await this.widget;
+
+        registry.registerCommand(TraceExplorerCommands.OPEN_TRACE, {
+            execute: (traceUUID: string) => {
+                explorerWidget.openExperiment(traceUUID);
+            }
+        });
+
+        registry.registerCommand(TraceExplorerCommands.CLOSE_TRACE, {
+            execute: (traceUUID: string) => {
+                explorerWidget.closeExperiment(traceUUID);
+            }
+        });
+
+        registry.registerCommand(TraceExplorerCommands.DELETE_TRACE, {
+            execute: (traceUUID: string) => {
+                explorerWidget.deleteExperiment(traceUUID);
+            }
+        });
+    }
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-widget.tsx
@@ -27,8 +27,24 @@ export class TraceExplorerWidget extends BaseWidget {
         return this.openedTracesWidget.experimentSelectedSignal;
     }
 
+    openExperiment(traceUUID: string): void {
+        return this.openedTracesWidget.openExperiment(traceUUID);
+    }
+
+    closeExperiment(traceUUID: string): void {
+        return this.openedTracesWidget.closeExperiment(traceUUID);
+    }
+
+    deleteExperiment(traceUUID: string): void {
+        return this.openedTracesWidget.deleteExperiment(traceUUID);
+    }
+
     onOpenedTracesWidgetActivated(experiment: Experiment): void {
         return this.openedTracesWidget.onWidgetActivated(experiment);
+    }
+
+    getExperiment(traceUUID: string): Experiment | undefined {
+        return this.openedTracesWidget.getExperiment(traceUUID);
     }
 
     static createWidget(parent: interfaces.Container): TraceExplorerWidget {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -4,3 +4,8 @@ export const OpenTraceCommand: Command = {
     id: 'open-trace',
     label: 'Open Trace'
 };
+
+export const TraceViewerCommand: Command = {
+    id: 'trace-viewer',
+    label: 'Trace Viewer'
+};


### PR DESCRIPTION
On Click of 'x' in trace-viewer tab doesn't delete the experiment from trace explorer.
Added a context menu to open, close and delete traces.

fixes #149

Signed-off-by: muddana-satish <satish.muddana@ericsson.com>