### PR TITLE
Set cancelable flag in progress monitor for opening of traces

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -106,7 +106,10 @@ export class TraceViewerWidget extends ReactWidget {
 
         // This will show a progress dialog with "Cancel" option
         this.messageService.showProgress({
-            text: 'Open traces'
+            text: 'Open traces',
+            options: {
+                cancelable: true
+            }
         },
             () => {
                 isCancelled.value = true;


### PR DESCRIPTION
This is necessary because the latest Theia version changed the default
behavior to align with VsCode.

Fixes #256

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>