### PR TITLE
Add support for arrows

### DIFF
--- a/packages/react-components/src/components/data-providers/tsp-data-provider.ts
+++ b/packages/react-components/src/components/data-providers/tsp-data-provider.ts
@@ -118,8 +118,8 @@ export class TspDataProvider {
             }
         }
         const offset = this.timeGraphEntries[0].start;
-        this.timeGraphArrows.filter(arrow => ids.find(
-            id => id === arrow.sourceId) || ids.find(id => id === arrow.targetId));
+        this.timeGraphArrows = this.timeGraphArrows.filter(arrow => ids.find(
+            id => id === arrow.sourceId) && ids.find(id => id === arrow.targetId));
         const arrows = this.timeGraphArrows.map(arrow => ({
             sourceId: ids.indexOf(arrow.sourceId),
             destinationId: ids.indexOf(arrow.targetId),

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { TimeGraphRowElement, TimeGraphRowElementStyle } from 'timeline-chart/lib/components/time-graph-row-element';
 import { TimeGraphChart, TimeGraphChartProviders } from 'timeline-chart/lib/layer/time-graph-chart';
+import { TimeGraphChartArrows } from 'timeline-chart/lib/layer/time-graph-chart-arrows';
 import { TimeGraphChartCursors } from 'timeline-chart/lib/layer/time-graph-chart-cursors';
 import { TimeGraphChartGrid } from 'timeline-chart/lib/layer/time-graph-chart-grid';
 import { TimeGraphChartSelectionRange } from 'timeline-chart/lib/layer/time-graph-chart-selection-range';
@@ -38,6 +39,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     private chartLayer: TimeGraphChart;
     private vscrollLayer: TimeGraphVerticalScrollbar;
     private chartCursors: TimeGraphChartCursors;
+    private arrowLayer: TimeGraphChartArrows;
     private horizontalContainer: React.RefObject<HTMLDivElement>;
 
     private tspDataProvider: TspDataProvider;
@@ -75,6 +77,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             })
         };
         this.chartLayer = new TimeGraphChart('timeGraphChart', providers, this.rowController);
+        this.arrowLayer = new TimeGraphChartArrows('timeGraphChartArrows', this.rowController);
         this.vscrollLayer = new TimeGraphVerticalScrollbar('timeGraphVerticalScrollbar', this.rowController);
         this.chartCursors = new TimeGraphChartCursors('chart-cursors', this.chartLayer, this.rowController, { color: this.props.style.cursorColor });
         this.rowController.onVerticalOffsetChangedHandler(() => {
@@ -153,6 +156,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         if (prevState.outputStatus === ResponseStatus.RUNNING ||
             this.state.collapsedNodes !== prevState.collapsedNodes) {
             this.chartLayer.updateChart();
+            this.arrowLayer.update();
         }
     }
 
@@ -279,7 +283,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             unitController={this.props.unitController}
             id='timegraph-chart'
             layer={[
-                grid, this.chartLayer, selectionRange, this.chartCursors
+                grid, this.chartLayer, selectionRange, this.chartCursors, this.arrowLayer
             ]}
         >
         </ReactTimeGraphContainer>;
@@ -319,6 +323,9 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         const newResolution: number = resolution * 0.8;
         const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(orderedTreeIds, this.state.timegraphTree,
             this.props.range, newRange, this.props.style.chartWidth);
+        if (timeGraphData.arrows.length > 0) {
+            this.arrowLayer.addArrows(timeGraphData.arrows);
+        }
         return {
             rows: timeGraphData ? timeGraphData.rows : [],
             range: newRange,

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -323,9 +323,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         const newResolution: number = resolution * 0.8;
         const timeGraphData: TimelineChart.TimeGraphModel = await this.tspDataProvider.getData(orderedTreeIds, this.state.timegraphTree,
             this.props.range, newRange, this.props.style.chartWidth);
-        if (timeGraphData.arrows.length > 0) {
-            this.arrowLayer.addArrows(timeGraphData.arrows);
-        }
+        this.arrowLayer.addArrows(timeGraphData.arrows);
         return {
             rows: timeGraphData ? timeGraphData.rows : [],
             range: newRange,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15330,9 +15330,9 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timeline-chart@next:
-  version "0.2.0-next.b33a5cfb"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0-next.b33a5cfb.tgz#9a864bff76d3aa52cea2d8f6d1f7680f743feaa0"
-  integrity sha512-0txCF0aZmNRENmEZHX4spWIE8YAbXIfSXUfaNH08vLrhtNbqaMpPQ2OqenIUwrb9WtA0sgOozARknuBGdANw1w==
+  version "0.2.0-next.885dec8e"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0-next.885dec8e.tgz#ea69bf2ab823210207247cd8561a3239c53ccc1b"
+  integrity sha512-3TlYQ/qgxmtObz1JgbsH7NoEmoFvBOnofC52uKTNpVWk4MW9reTluih7xRx4/zV1iaF9mjMkwIGqzmlMMyDR8Q==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"
@@ -15543,9 +15543,9 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsp-typescript-client@next:
-  version "0.2.0-next.5f4f154"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.5f4f154.tgz#5ef1c569e4a3950f7a2da5705de32d7ebcb0f7dc"
-  integrity sha512-vJPuIPBuAzju8BRZ6SpSfkTUNiSNuDjcZ7rElZQUd6aEqerx1/M9qKhbVED2dPbpEJF1nd9zNZusrQNjvFyxxg==
+  version "0.2.0-next.b2470f2"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.b2470f2.tgz#bbb0cfe8623441f73bc565322bf80099486acd25"
+  integrity sha512-1SUG7rVDjRLAMxXa4t+XczkvYPFCzAal9J6Qedd/ZrRVO4wVo/HkujuO0xZqEGj8HRHmCUFkD2GYQs9oxE++4g==
   dependencies:
     node-fetch "^2.5.0"
 


### PR DESCRIPTION
This change makes use of the getData provider of the time-graph-chart.
Another way of implementing it would to change time-graph-chart-arrows  to have its own data provider.

This change fixes #39 and it is dependent on:
- github.com/theia-ide/timeline-chart/pull/115
- github.com/theia-ide/tsp-typescript-client/pull/19
- git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/177071

Signed-off-by: Arnaud Fiorini <fiorini.arnaud@gmail.com>