### PR TITLE
menu: fix duplicate 'open trace' command

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
@@ -6,7 +6,6 @@ export namespace TraceExplorerMenus {
 export namespace TraceExplorerCommands {
     export const OPEN_TRACE: Command = {
         id: 'trace-explorer:open-trace',
-        label: 'Open Trace'
     };
 
     export const CLOSE_TRACE: Command = {

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -26,7 +26,7 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
         super.registerMenus(menus);
         menus.registerMenuAction(TraceExplorerMenus.PREFERENCE_EDITOR_CONTEXT_MENU, {
             commandId: TraceExplorerCommands.OPEN_TRACE.id,
-            label: TraceExplorerCommands.OPEN_TRACE.label,
+            label: 'Open Trace',
             order: 'a'
         });
 


### PR DESCRIPTION
#### Description

Fixes: #289

The following commit fixes the issue where a duplicate `open trace` command was present in the command palette. Instead of registering the command with a label (which makes it show up in the command palette), the label is added to the menu only.

_Note_: only commands with `labels` will show up in the command palette.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>