### PR TITLE
Fixed event_table component's font-family/font-size

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -95,3 +95,17 @@ canvas {
     width: 180px;
     color: var(--theia-input-placeholder-foreground)
 }
+
+.ag-theme-balham{
+    font-family: var(--theia-ui-font-family) !important;
+    font-size: var(--theia-content-font-size) !important;
+}
+
+.ag-theme-balham-dark{
+    font-family: var(--theia-ui-font-family) !important;
+    font-size: var(--theia-content-font-size) !important;
+}
+
+.ag-theme-balham-dark .ag-row-selected {
+    background-color: var(--theia-selection-background) !important;
+}


### PR DESCRIPTION
fixes #216

-The ag-grid has default color for selected row which isn't consistent
with theia's font family and font size. This change will override those
default values.

Signed-off-by: Ankush Tyagi <ankush.tyagi@ericsson.com>