### PR TITLE
Change "no view" warning to direct users to trace viewer tab

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -278,7 +278,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         return <div className='no-output-placeholder'>
             {'Trace loaded successfully.'}
             <br />
-            {'To see available views, open the Trace Explorer view.'}
+            {'To see available views, open the Trace Viewer.'}
         </div>;
     }
 


### PR DESCRIPTION
The name of the trace explorer has been change to viewer, update
the warning message to reflect this.

Signed-off-by: Matthew Khouzam <matthew.khouzam@ericsson.com>