### PR TITLE
Click and drag to move across the entire title bar

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -13,7 +13,7 @@
 .title-bar-label {
     text-align: center;
     writing-mode: vertical-rl;
-    height: 50%;
+    height: 100%;
     min-height: 150px;
     transform: rotate(180deg);
     user-select: none;


### PR DESCRIPTION
We can now click and drag to move across the entire title bar 

Fixes #239
**Here is the result**

![issue entire bar](https://user-images.githubusercontent.com/83769103/118659587-73881e80-b7bb-11eb-98f9-d5b90827e171.gif)

Signed-off-by: Ibrahim Fradj <ibrahim.fradj@ericsson.com>