### PR TITLE
Include trace server with packaged app

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -9,7 +9,7 @@
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
           "editor.autoSave": "on",
-          "trace-viewer.path" : "../../trace-compass-server/tracecompass-server",
+          "trace-viewer.path" : "trace-compass-server/tracecompass-server",
           "trace-viewer.port" : 8080
 
         }

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -3,7 +3,10 @@
   "name": "electron-theia-trace-example-app",
   "main": "scripts/theia-trace-main.js",
   "build": {
-    "electronVersion": "9.1.2"
+    "electronVersion": "9.1.2",
+    "extraResources": [
+      { "from": "../../trace-compass-server", "to": "trace-compass-server"}
+    ]
   },
   "version": "0.0.1",
   "theia": {
@@ -18,7 +21,7 @@
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
           "editor.autoSave": "on",
-          "trace-viewer.path" : "../../trace-compass-server/tracecompass-server",
+          "trace-viewer.path" : "../trace-compass-server/tracecompass-server",
           "trace-viewer.port" : 8080
         }
       }


### PR DESCRIPTION
Modifies the way the path is obtained to work with the AppImage application. Also adds meaningful error messages when the path is not correct.

Related to #352 

Motivation: Currently, users need to compile the Trace Viewer from source to view their own traces. To avoid the time-consuming dev setup and compilation we now offer a downloadable package (electron desktop application + trace server). Since this package currently needs to be generated and uploaded manually, this PR includes the packaging changes required so that any dev can easily create an updated package in the future.

Signed-off-by: Arnaud Fiorini <fiorini.arnaud@gmail.com>