### PR TITLE
Hide analysis that is not implemented on the client side

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -158,6 +158,6 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         if (descriptors && descriptors.length) {
             outputDescriptors.push(...descriptors);
         }
-        return outputDescriptors;
+        return outputDescriptors.filter(value => value.type !== 'DATA_TREE');
     }
 }


### PR DESCRIPTION
 
I have filtered out the view type that is not implemented in the client side (DATA_TREE). The expected result is that views of this type are not displayed in the available views 

Contributes towards fixing #296

**Before**

![image](https://user-images.githubusercontent.com/83769103/121736295-5f3af700-cac5-11eb-94bd-9f009d6a0371.png)

**After**

![image](https://user-images.githubusercontent.com/83769103/121741162-1dfa1580-cacc-11eb-9d3d-8b348e980405.png)

In these two images, we notice that the Futex contention analysis is not shown in the next image because this view has a DATA_TREE type. 


Signed-off-by: Ibrahim Fradj <ibrahim.fradj@ericsson.com>