### PR TITLE
Make server port (8080) public

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,7 @@ ports:
   onOpen: ignore
 - port: 8080 # Trace Compass server
   onOpen: ignore
+  visibility: public
 tasks:
 - init: >
     yarn download:server


### PR DESCRIPTION
Gitpod recently changed their default port visibility from public to
private (gitpod-io/gitpod#4548). This made it impossible for the front 
end to automatically connect to the trace server (see #415). Making the
port used by the server (8080) public solves this issue.

Fixes #415

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>