### PR TITLE
Do not open TraceViewerWidget when initializing layout

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -28,9 +28,10 @@ export default new ContainerModule(bind => {
     bind(TspClientProvider).toSelf().inSingletonScope();
     bind(TheiaMessageManager).toSelf().inSingletonScope();
 
-    bindViewContribution(bind, TraceViewerToolbarContribution);
+    bind(TraceViewerToolbarContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TraceViewerToolbarContribution);
     bind(TabBarToolbarContribution).toService(TraceViewerToolbarContribution);
+    bind(CommandContribution).toService(TraceViewerToolbarContribution);
 
     bind(TraceViewerWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({


### PR DESCRIPTION
This PR fixes #411 by removing the bindings that were causing a `TraceViewerWidget` to be created when the layout was restored.

The `TraceViewerToolbarContribution` was `extending` `AbstractViewContribution` and implementing `initializeLayout`, but it doesn't need any `ViewContribution` functionality and should not try to open a widget on startup.

To test:
1. Open a trace and view some trace graphs.
2. You should have access to the same commands and toolbar items as on `master`.
3. Run the `View: Reset Workbench Layout` command.
4. You should not see any logs about widgets missing id's or inability to read `traceURI` of `null`.

> I see an error `Cannot read property 'annotationCategories' of null` logged by `trace-explorer-views-widget.tsx`, but I believe that that error is unrelated to these changes.

Signed-off-by: Colin Grant <colin.grant@ericsson.com>

