### PR TITLE
Cleanup: Remove manual trace server start in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,8 +16,6 @@ ports:
 tasks:
 - init: >
     yarn download:server
-  command: >
-    yarn start:server
 - init: >
     yarn download:sample-traces &&
     yarn


### PR DESCRIPTION
The server has been managed automatically (start/stop) since PR #298.
Removing the manual trace server start reduces possible sources of bugs
because of interference with the manual and automatic server
management.

----

Submitting as a draft since I'm not sure if changes should be made to 
the [export statements](https://github.com/ebugden/theia-trace-extension/blob/d8c5048a56eb4d0d20a15e6fc6136335635f4c92/.gitpod.yml#L22) a couple lines below:

`command: >
export GITPOD_URL=$(gp url 8080) &&
export TRACE_SERVER_URL=$(echo "$GITPOD_URL/tsp/api")`

Are the export statements defining on which port the trace server should start?
Or specifying which port the server was manually started on?

----

Fixes #319

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>