### PR TITLE
trace-explorer: correct a key error for the else case

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-tooltip-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-tooltip-widget.tsx
@@ -52,7 +52,7 @@ export class TraceExplorerTooltipWidget extends ReactWidget {
                 }
             });
         } else {
-            tooltipArray.push(<p><i>Select item to view properties</i></p>);
+            tooltipArray.push(<p key="-1"><i>Select item to view properties</i></p>);
         }
 
         return (


### PR DESCRIPTION
Correct the error: "Each child in a list should have a unique “key” prop" for the else case.
Signed-off-by: Arnaud Fiorini <fiorini.arnaud@gmail.com>