### PR TITLE
Fix misalignment between labels and rows

### DIFF
--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -101,7 +101,6 @@ canvas {
     line-height: 18px;
     position: relative;
     white-space: nowrap;
-    top: 50%;
     padding: 0 0;
 }
 


### PR DESCRIPTION
Fix misalignment between labels and rows in the Resources Status and Thread Status views.

In Chrome, the first line of the labels in the side bar of these views would not be aligned with the first row of the data. It would be located much lower in the view.

See attached images of the Resources Status view in Chrome and Firefox (added for comparison), before and after the fix.

Chrome before fix:
![Chrome-before](https://user-images.githubusercontent.com/88502808/128896740-8cdfa9be-d845-4703-9237-c16e80279cc4.png)

Chrome after fix:
![Chrome-after](https://user-images.githubusercontent.com/88502808/128896491-e707c57c-81aa-4f9c-ab66-39fb36adae0a.png)

Firefox before fix:
![Firefox-before](https://user-images.githubusercontent.com/88502808/128896550-2b0e7e62-1bc8-4edc-81a8-7d8725eb36f4.png)

Firefox after fix:
![Firefox-after](https://user-images.githubusercontent.com/88502808/128896562-ee3a95c1-f8b2-4d8d-b9fe-9d4c4329aa3f.png)

