### PR TITLE
Show view message when there is no data to provide

### DIFF
--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -93,6 +93,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
                     xyTree: treeResponse.model.entries,
                     columns
                 });
+            } else {
+                this.setState({
+                    outputStatus: treeResponse.status
+                });
             }
             return treeResponse.status;
         }
@@ -159,6 +163,17 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             events: [ 'mousedown' ],
         };
         // width={this.props.style.chartWidth}
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0 ) {
+            return <React.Fragment>
+                {
+                    <p className='no-data' style={{fontSize: 20, marginRight: '5px', marginLeft: '5px', justifyContent:'center', alignItems:'center'}}>
+                        Trace analysis completed.
+                        No results: Trace missing required events.
+                    </p>
+                }
+            </React.Fragment>;
+        }
+
         return <React.Fragment>
             {this.state.outputStatus === ResponseStatus.COMPLETED ?
                 <div id='xy-main' onMouseDown={event => this.beginSelection(event)} style={{ height: this.props.style.height }} >

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -81,6 +81,16 @@ canvas {
     align-self: center;
 }
 
+.no-data {
+    font-size: 24px;
+    text-align: center;
+    position: relative;
+    transform: translate(0, -50%);
+    top: 50%;
+    width: 90%;
+    align-self: center;
+}
+
 .table-tree>tbody>tr:nth-child(1)>th {
     background-color: var(--theia-editor-background);
     position: sticky;


### PR DESCRIPTION
Some views weren't able to display any data after the completion of the trace's analysis.
The problem was due to the fact that some provided models are empty server side because
they were no relevents trace events to display.

We choose to display a message indicating that there are no data to display in those cases
and update the state of the analysis client side. It will allow a better clarity of the user
experience.

Fixes #406
Signed-off-by: Jeff Godonou <jeffalecgodonou@gmail.com>