### PR TITLE
Allow editing trace set labels via Opened Traces widget

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -23,6 +23,7 @@ export declare interface SignalManager {
 }
 
 export const Signals = {
+    EXPERIMENT_CHANGED: 'tab changed',
     TRACE_OPENED: 'trace opened',
     TRACE_CLOSED: 'trace closed',
     EXPERIMENT_OPENED: 'experiment opened',
@@ -43,6 +44,9 @@ export const Signals = {
 };
 
 export class SignalManager extends EventEmitter implements SignalManager {
+    fireExperimentChangedSignal(tabName: string, experimentUUID: string): void {
+        this.emit(Signals.EXPERIMENT_CHANGED, { tabName, experimentUUID });
+    }
     fireTraceOpenedSignal(trace: Trace): void {
         this.emit(Signals.TRACE_OPENED, trace);
     }

--- a/packages/react-components/src/trace-explorer/menu-item-trace.tsx
+++ b/packages/react-components/src/trace-explorer/menu-item-trace.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import { Trace } from 'tsp-typescript-client';
+import { signalManager, Signals } from '@trace-viewer/base/lib/signals/signal-manager';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+
+interface MenuItemProps {
+    index: number;
+    experimentName: string;
+    experimentUUID: string;
+    traces: Trace[];
+    onExperimentNameChange: (newExperimentName: string, index: number) => void;
+    menuItemTraceContainerClassName: string;
+    handleClickEvent: (event: React.MouseEvent<HTMLDivElement>, experimentName: string) => void;
+    handleContextMenuEvent: (event: React.MouseEvent<HTMLDivElement>, experimentUUID: string) => void;
+}
+interface MenuItemState {
+    editingTab: boolean;
+    oldExperimentName: string;
+    experimentNameState: string;
+}
+
+export class MenuItemTrace extends React.Component<MenuItemProps, MenuItemState> {
+
+    private wrapper: React.RefObject<HTMLDivElement>;
+
+    constructor(menuItemProps: MenuItemProps) {
+        super(menuItemProps);
+        this.state = {
+            oldExperimentName: this.props.experimentName,
+            experimentNameState: this.props.experimentName,
+            editingTab: false
+        };
+        this.wrapper = React.createRef();
+        this.handleClickOutside = this.handleClickOutside.bind(this);
+    }
+
+    submitNewExperimentName(): void {
+        if (this.state.experimentNameState.length > 0) {
+            this.setState({
+                editingTab: false,
+                oldExperimentName: this.state.experimentNameState
+            });
+            this.props.onExperimentNameChange(this.state.experimentNameState, this.props.index);
+        } else {
+            this.setState({
+                editingTab: false,
+                experimentNameState: this.state.oldExperimentName
+            });
+            const tabName = 'Trace: ' + this.state.oldExperimentName;
+            signalManager().fireExperimentChangedSignal(tabName, this.props.experimentUUID);
+        }
+        document.removeEventListener('click', this.handleClickOutside);
+    }
+
+    handleClickOutside = (event: Event): void => {
+        const node = this.wrapper.current;
+        if ((!node || !node.contains(event.target as Node)) && this.state.editingTab === true) {
+            this.submitNewExperimentName();
+        }
+    };
+
+    protected handleEnterPress(event: React.KeyboardEvent<HTMLInputElement>): void{
+        if (event.key === 'Enter' && this.state.editingTab === true){
+            this.submitNewExperimentName();
+        }
+    }
+
+    protected changeText(event: React.ChangeEvent<HTMLInputElement>): void{
+        let newName = event.target.value.toString();
+        this.setState({
+            experimentNameState : newName
+        });
+        newName = 'Trace: ' + newName;
+        signalManager().fireExperimentChangedSignal(newName,  this.props.experimentUUID);
+    }
+    protected inputTab(): React.ReactNode {
+        if (!this.state.editingTab) {
+            return (
+            <div className='wrapper'>
+                {this.state.experimentNameState}
+                <div className='edit-trace-name' onClick={e => {this.renderEditTraceName(e);}}>
+                    <FontAwesomeIcon icon={faPencilAlt} />
+                </div>
+            </div>
+            );
+        }
+        return (<input name="tab-name" className="theia-input name-input-box"
+            defaultValue = {this.state.experimentNameState}
+            onChange = {e => (this.changeText(e))}
+            onClick = {e => e.stopPropagation()}
+            onKeyPress = {e => (this.handleEnterPress(e))}
+            maxLength = {50}
+        />);
+    }
+    protected renderEditTraceName(event: React.MouseEvent<HTMLDivElement>): void {
+        document.addEventListener('click', this.handleClickOutside);
+        this.setState(() => ({
+            editingTab: true
+        }));
+        event.stopPropagation();
+        event.preventDefault();
+    }
+    protected renderTracesForExperiment = (): React.ReactNode => this.doRenderTracesForExperiment();
+    protected doRenderTracesForExperiment(): React.ReactNode {
+        const tracePaths = this.props.traces;
+        return (
+            <div className='trace-element-path-container'>
+                {tracePaths.map(trace => (
+                    <div className='trace-element-path child-element' id={trace.UUID} key={trace.UUID}>
+                        {` > ${trace.name}`}
+                    </div>
+                ))}
+            </div>
+        );
+    }
+    protected subscribeToExplorerEvents(): void {
+        signalManager().on(Signals.OUTPUT_ADDED, this.changeText);
+    }
+
+    render(): JSX.Element {
+        return (
+            <div className={this.props.menuItemTraceContainerClassName}
+            id={`${this.props.menuItemTraceContainerClassName}-${this.props.index}`}
+            onClick={event => {
+                    this.props.handleClickEvent(event, this.props.experimentUUID);
+                }
+            }
+            onContextMenu={event => { this.props.handleContextMenuEvent(event, this.props.experimentUUID); }}
+            data-id={`${this.props.index}`}
+            ref={this.wrapper}>
+            <div className='trace-element-container'>
+                <div className='trace-element-info' >
+                    <h4 className='trace-element-name'>
+                        {this.inputTab()}
+                    </h4>
+                    { this.renderTracesForExperiment() }
+                </div>
+                {/* <div className='trace-element-options'>
+                    <button className='share-context-button' onClick={this.handleShareButtonClick.bind(this, props.index)}>
+                        <FontAwesomeIcon icon={faShareSquare} />
+                    </button>
+                </div> */}
+            </div>
+        </div>
+        );
+    }
+}

--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -53,7 +53,29 @@
 
 .trace-list-container.theia-mod-selected,
 .outputs-list-container.theia-mod-selected {
-    background-color: var(--theia-selection-background);
+    background-color: #3b3a4a;
+}
+
+.trace-list-container:hover .edit-trace-name {
+    visibility: visible;
+    float: right;
+}
+
+.trace-list-container:hover .wrapper {
+    background-color: #151515;
+}
+
+.trace-list-container .edit-trace-name {
+    visibility: hidden;
+}
+
+.name-input-box {
+    background-color: #151515;
+    margin-bottom: 5px;
+    width: 100%;
+    height: 18px;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 /* Share options have been commented out, grid is disabled to optimize horizontal space */
@@ -75,7 +97,10 @@
 
 .trace-element-name, .outputs-element-name {
     font-weight: bold;
-    margin: unset;
+    margin-top: unset;
+    margin-left: unset;
+    margin-right: unset;
+    margin-bottom: 2px;
     height: var(--trace-extension-list-line-height);
 }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -54,6 +54,7 @@ export class TraceViewerWidget extends ReactWidget {
     private onOutputAdded = (payload: OutputAddedSignalPayload): void => this.doHandleOutputAddedSignal(payload);
     private onExperimentSelected = (experiment: Experiment): void => this.doHandleExperimentSelectedSignal(experiment);
     private onCloseExperiment = (UUID: string): void => this.doHandleCloseExperimentSignal(UUID);
+    private onExperimentNameChange = (payload: { tabName: string, experimentUUID: string; }): void => this.doHandleExperimentNameChange(payload);
 
     @inject(TraceViewerWidgetOptions) protected readonly options: TraceViewerWidgetOptions;
     @inject(TspClientProvider) protected tspClientProvider: TspClientProvider;
@@ -111,11 +112,18 @@ export class TraceViewerWidget extends ReactWidget {
         signalManager().on(Signals.OUTPUT_ADDED, this.onOutputAdded);
         signalManager().on(Signals.EXPERIMENT_SELECTED, this.onExperimentSelected);
         signalManager().on(Signals.CLOSE_TRACEVIEWERTAB, this.onCloseExperiment);
+        signalManager().on(Signals.EXPERIMENT_CHANGED, this.onExperimentNameChange);
     }
 
     protected updateBackgroundTheme(): void {
         const currentThemeType = ThemeService.get().getCurrentTheme().type;
         signalManager().fireThemeChangedSignal(currentThemeType);
+    }
+
+    protected doHandleExperimentNameChange(payload: { tabName: string, experimentUUID: string; }): void {
+        if (payload.experimentUUID === this.options.traceUUID) {
+            this.title.label = payload.tabName;
+        }
     }
 
     dispose(): void {


### PR DESCRIPTION
Contributes towards fixing #384 (changing the trace set label also changes the tab label for that trace). 

Known Issues: 
- Default trace tab opened **on launch of trace server** does not have its tab renamed, issue is unrelated to code changes. @arfio is aware of this
- Editing tab could use a bit more padding

Default Behaviour:
- After consulting with @ebugden, both clicking outside the menu item and pressing enter will save the tab name and changes will be reflected in both the menu item and the tab name. @ssmagula
- Max tab length of 50 characters
- If 0 characters are inputed, tab name and menu item name are reverted to their state before they were being edited

Signed-off-by: Nikolai Peram <nikolai_peram@outlook.com>