### PR TITLE
Null check annotation categories

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -133,7 +133,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
             const annotationCategories = await tspClient.fetchAnnotationsCategories(this._selectedExperiment?.UUID, output.id);
             const annotationCategoriesResponse = annotationCategories.getModel();
             if (annotationCategories.isOk() && annotationCategoriesResponse) {
-                const categoriesList = annotationCategoriesResponse.model.annotationCategories;
+                const categoriesList = annotationCategoriesResponse.model ? annotationCategoriesResponse.model.annotationCategories : [];
                 signalManager().fireAnnotationsFetchedSignal(categoriesList);
             }
         }


### PR DESCRIPTION
Avoid a null pointer access if no annotation categories are provided. (e.g. with the flame chart)

Fixes front-end issue with 438

Signed-off-by: Matthew Khouzam <matthew.khouzam@ericsson.com>