### PR TITLE
We can zoom with +/- and reset the zoom 

### DIFF
--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -53,9 +53,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     private styleMap = new Map<string, TimeGraphStateStyle>();
 
     private selectedElement: TimeGraphStateComponent | undefined;
-
-    private onTimeGraphZoomed = (hasZoomedIn: boolean) => this.doHandleTimeGraphZoomedSignal(hasZoomedIn);
-    private onTimeGraphReset = () => this.doHandleTimeGraphResetSignal();
     private annotationMarkers: string[] | undefined = undefined;
     private onSelectionChanged = (payload: { [key: string]: string; }) => this.doHandleSelectionChangedSignal(payload);
     private onMarkerFilterChanged = (annotationMarkers: string[]) => this.doHandleMarkerFilterChangedSignal(annotationMarkers);
@@ -116,8 +113,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
             }
         });
         signalManager().on(Signals.SELECTION_CHANGED, this.onSelectionChanged);
-        signalManager().on(Signals.TIMEGRAPH_ZOOMED, this.onTimeGraphZoomed);
-        signalManager().on(Signals.TIMEGRAPH_RESET, this.onTimeGraphReset);
         signalManager().on(Signals.ANNOTATION_MARKERS_FILTERED, this.onMarkerFilterChanged);
     }
 
@@ -137,8 +132,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     componentWillUnmount(): void {
         super.componentWillUnmount();
         signalManager().off(Signals.SELECTION_CHANGED, this.onSelectionChanged);
-        signalManager().off(Signals.TIMEGRAPH_ZOOMED, this.onTimeGraphZoomed);
-        signalManager().off(Signals.TIMEGRAPH_RESET, this.onTimeGraphReset);
     }
 
     async fetchTree(): Promise<ResponseStatus> {
@@ -220,12 +213,6 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         }
     }
 
-    private doHandleTimeGraphZoomedSignal(hasZoomedIn: boolean) {
-        this.chartLayer.adjustZoom(undefined, hasZoomedIn);
-    }
-    private doHandleTimeGraphResetSignal() {
-        this.props.unitController.viewRange = { start: 0, end: this.props.unitController.absoluteRange };
-    }
     private doHandleMarkerFilterChangedSignal(annotationMarkers: string[]) {
         this.annotationMarkers = annotationMarkers;
         this.chartLayer.updateChart();

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -12,6 +12,7 @@ import { EntryTree } from './utils/filtrer-tree/entry-tree';
 import { getAllExpandedNodeIds } from './utils/filtrer-tree/utils';
 import { TreeNode } from './utils/filtrer-tree/tree-node';
 import ColumnHeader from './utils/filtrer-tree/column-header';
+import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 
 type XYOuputState = AbstractOutputState & {
     selectedSeriesId: number[];
@@ -481,6 +482,16 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
                 case 'd':
                 case 'ArrowRight': {
                     this.pan(PAN_RIGHT);
+                    break;
+                }
+                case '+':
+                case '=': {
+                    signalManager().fireZoomTimeGraphSignal(true);
+                    break;
+                }
+                case '-':
+                case '_': {
+                    signalManager().fireZoomTimeGraphSignal(false);
                     break;
                 }
             }


### PR DESCRIPTION
 We can zoom in/out and reste with the toolbar button centered on the selection.

 We can zoom in/out with +/- in the keyboard centered on the selection.

 If the selection is not visible the zoom will be done in the middle of the range we see.

 Contributes towards fixing theia-ide#389

Signed-off-by: Ibrahim Fradj <ibrahim.fradj@ericsson.com>