### PR TITLE
Filter XY chart type

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -171,7 +171,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         if (descriptors && descriptors.length) {
             outputDescriptors.push(...descriptors);
         }
-        return outputDescriptors.filter(value => value.type !== 'DATA_TREE');
+        return outputDescriptors.filter(value => value.type !== 'DATA_TREE' && value.type !== 'TREE_TIME_XY');
     }
 }
 


### PR DESCRIPTION
Currently, XY charts are missing y-axis labels and units so it is
impossible for users to learn how to interpret the data shown in these
charts using the tool. Without a sense of scale, XY charts have little
analysis use and mainly distract users from views that are ready to be
used (ex. Timegraph views, Events table). Filter out XY chart views to
correct this.

For developers who need to test or demonstrate new features for XY
charts, the condition that filters XY charts
(value.type !== 'TREE_TIME_XY') can be temporarily removed to allow
testing XY chart features.

Fixes #296

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>