### PR TITLE
Only run publish-next build job for theia-ide/theia-trace-extension

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -6,6 +6,7 @@ on:
 #    types: [created]
 jobs:
   build:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'theia-ide/theia-trace-extension' 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This check added prevents the publish job to be run for forks of this
project.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>