### PR TITLE
improve the trace server spawning logic

### DIFF
--- a/theia-extensions/viewer-prototype/src/node/trace-server-service.ts
+++ b/theia-extensions/viewer-prototype/src/node/trace-server-service.ts
@@ -1,60 +1,91 @@
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import { injectable } from 'inversify';
 import { PortBusy, TraceServerConfigService } from '../common/trace-server-config';
 import treeKill = require('tree-kill');
 
+const SUCCESS = 'success';
+
 @injectable()
 export class TraceServerServiceImpl implements TraceServerConfigService {
-    private processId: number;
 
-    startTraceServer(path: string | undefined, port: number | undefined): Promise<string> {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const server = spawn(path!, ['-vmargs', `-Dtraceserver.port=${port}`]);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.processId = server.pid!;
-        const timeouts: NodeJS.Timeout[] = [];
+    private server?: ChildProcess;
+    private port?: number;
 
-        return new Promise<string>((resolve, reject) => {
-            // TODO: Since the resolve never actually gets returned, we need a better way to determine if the child process
-            // initiated by the spawn successfully starts the trace server
-
-            // If the server doesn't error or exit within 2 seconds, we consider that a success.
-            // That doesn't mean that the server has really started. On the frontend, the `TraceServerConnectionStatusService`
-            // will ping the port until it receives a response, which is the official measure of success.
-
-            timeouts.push(setTimeout(() => resolve('success'), 2000));
-
-            // If the server exits or errors before it outputs, consider it a failure.
-            server.on('error', err => {
-                reject(err);
+    async startTraceServer(path?: string, port?: number): Promise<string> {
+        if (path === undefined) {
+            throw new Error('no Trace Server path specified');
+        } else if (port === undefined) {
+            throw new Error('no Trace Server port specified');
+        } else if (this.isServerRunning(this.server)) {
+            if (this.port === port) {
+                return SUCCESS;
+            } else {
+                throw new Error('the Trace Server is already running on a different port');
+            }
+        }
+        const server = spawn(path, ['-vmargs', `-Dtraceserver.port=${port}`]);
+        if (server.pid === undefined) {
+            // When pid is undefined it usually means we're about to get an error.
+            return new Promise<never>((_, reject) => server.once('error', reject));
+        }
+        this.server = server;
+        this.port = port;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let timeout: any;
+        try {
+            await new Promise<void>((resolve, reject) => {
+                // If the server doesn't error or exit within 2 seconds, we consider that a success.
+                // That doesn't mean that the server has really started. On the frontend, the `TraceServerConnectionStatusService`
+                // will ping the port until it receives a response, which is the official measure of success.
+                timeout = setTimeout(resolve, 2000);
+                server.once('exit', (code, _signal) => reject(PortBusy(code)));
+                server.once('error', reject);
             });
-            server.on('exit', code => {
-                reject(PortBusy(code));
-            });
-            // If no response recieved from the trace server in 10 seconds, reject with an error (for internal use)
-            timeouts.push(setTimeout(() => reject('Waited 10 seconds but nothing happened and hence exiting'), 10000));
-
-        }).finally(() => {
+        } catch (error) {
+            this.server = undefined;
+            this.port = undefined;
+            throw error;
+        } finally {
             server.removeAllListeners();
-            timeouts.forEach(timeout => clearTimeout(timeout));
+            clearTimeout(timeout);
+        }
+        server.once('exit', () => {
+            this.server = undefined;
+            this.port = undefined;
         });
-
+        return SUCCESS;
     }
 
-    stopTraceServer(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            if (this.processId === -1 || !this.processId) {
-                reject('process already killed or process hasn\'t been started');
-                return;
-            }
-            treeKill(this.processId, error => {
-                this.processId = -1;
+    async stopTraceServer(): Promise<string> {
+        if (!this.isServerRunning(this.server)) {
+            return SUCCESS;
+        }
+        await new Promise<void>((resolve, reject) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let exitTimeout: any;
+            // Use `server.on('exit', ...)` as source of truth to detect if the server was successfully killed or not.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this.server!.once('exit', () => {
+                clearTimeout(exitTimeout);
+                resolve();
+            });
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            treeKill(this.server!.pid!, error => {
                 if (error) {
                     reject(error);
-                    return;
+                } else {
+                    // Give `server.on('exit', ...)` 1s to fire before rejecting with an error.
+                    exitTimeout = setTimeout(() => reject(new Error('the Trace Server did not exit')), 1000);
                 }
-                resolve('success');
             });
         });
+        return SUCCESS;
+    }
+
+    protected isServerRunning(server?: ChildProcess): boolean {
+        return server !== undefined &&
+            // When the process stops, one of `exitCode` or `signalCode` is set.
+            // eslint-disable-next-line no-null/no-null
+            server.exitCode === null && server.signalCode === null;
     }
 }


### PR DESCRIPTION
It is often easy to write JS code that works in general cases, but miss corner cases... Especially with the process API which I believe was designed to be the most painful thing to use.

Some quirks include:
- `pid` is `undefined` iff Node couldn't actually spawn the process,
- `childProcess.exitCode` or `childProcess.signalCode` are set when the process exits,
- `childProcess.pid` can outlive the process, so issuing a kill on it after the process actually exited may end up killing another process that ends up inheriting the same `pid` some time later.

There were some code oddities like ``spawn(`${path}`, ...)`` which most likely was some kind of workaround around the fact that `path` can be `undefined`... But in such a case it would try to do `spawn('undefined', ...)` which doesn't make any sense. Until someone figures out what it means to pass `undefined` to this method, we'll throw an error.

I cannot guaranty that this new implementation is 100% foolproof, but it's definitely more robust.