### PR TITLE
Use BigInt for timestamps

### DIFF
--- a/packages/base/src/utils/time-range.ts
+++ b/packages/base/src/utils/time-range.ts
@@ -1,7 +1,7 @@
 export class TimeRange {
-    private start: number;
-    private end: number;
-    private offset: number | undefined;
+    private start: bigint;
+    private end: bigint;
+    private offset: bigint | undefined;
 
     /**
      * Constructor.
@@ -9,7 +9,7 @@ export class TimeRange {
      * @param end Range end time
      * @param offset Time offset, if this is defined the start and end time should be relative to this value
      */
-    constructor(start: number, end: number, offset?: number) {
+    constructor(start: bigint, end: bigint, offset?: bigint) {
         this.start = start;
         this.end = end;
         this.offset = offset;
@@ -19,7 +19,7 @@ export class TimeRange {
      * Get the range start time.
      * If an offset is present the return value is start + offset.
      */
-    public getstart(): number {
+    public getStart(): bigint {
         if (this.offset !== undefined) {
             return this.start + this.offset;
         }
@@ -30,7 +30,7 @@ export class TimeRange {
      * Get the range end time.
      * If an offset is present the return value is end + offset.
      */
-    public getEnd(): number {
+    public getEnd(): bigint {
         if (this.offset !== undefined) {
             return this.end + this.offset;
         }
@@ -40,14 +40,14 @@ export class TimeRange {
     /**
      * Get range duration
      */
-    public getDuration(): number {
+    public getDuration(): bigint {
         return this.end - this.start;
     }
 
     /**
      * Return the time offset
      */
-    public getOffset(): number | undefined {
+    public getOffset(): bigint | undefined {
         return this.offset;
     }
 }

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -135,7 +135,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     async fetchTree(): Promise<ResponseStatus> {
-        const parameters = QueryHelper.timeQuery([this.props.range.getstart(), this.props.range.getEnd()]);
+        const parameters = QueryHelper.timeQuery([this.props.range.getStart(), this.props.range.getEnd()]);
         const tspClientResponse = await this.props.tspClient.fetchTimeGraphTree(this.props.traceId, this.props.outputDescriptor.id, parameters);
         const treeResponse = tspClientResponse.getModel();
         if (tspClientResponse.isOk() && treeResponse) {
@@ -199,12 +199,12 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
     }
 
     private doHandleSelectionChangedSignal(payload: { [key: string]: string }) {
-        const offset = this.props.viewRange.getOffset() || 0;
-        const startTimestamp = Number(payload['startTimestamp']);
-        const endTimestamp = Number(payload['endTimestamp']);
-        if (!isNaN(startTimestamp) && !isNaN(endTimestamp)) {
-            const selectionRangeStart = startTimestamp - offset;
-            const selectionRangeEnd = endTimestamp - offset;
+        const offset = this.props.viewRange.getOffset() || BigInt(0);
+        const startTimestamp = payload['startTimestamp'];
+        const endTimestamp = payload['endTimestamp'];
+        if (startTimestamp !== undefined && endTimestamp !== undefined) {
+            const selectionRangeStart = BigInt(startTimestamp) - offset;
+            const selectionRangeEnd = BigInt(endTimestamp) - offset;
             this.props.unitController.selectionRange = {
                 start: selectionRangeStart,
                 end: selectionRangeEnd
@@ -265,8 +265,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 start = this.props.unitController.numberTranslator(elementRange.start);
                 end = this.props.unitController.numberTranslator(elementRange.end);
             }
-            start = start ? start : (elementRange.start + (offset ? offset : 0)).toString();
-            end = end ? end : (elementRange.end + (offset ? offset : 0)).toString();
+            start = start ? start : (elementRange.start + (offset ? offset : BigInt(0))).toString();
+            end = end ? end : (elementRange.end + (offset ? offset : BigInt(0))).toString();
             const tooltip = await this.tspDataProvider.fetchStateTooltip(element, this.props.viewRange);
             return {
                 'Label': label,
@@ -286,8 +286,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 start = this.props.unitController.numberTranslator(elementRange.start);
                 end = this.props.unitController.numberTranslator(elementRange.end);
             }
-            start = start ? start : (elementRange.start + (offset ? offset : 0)).toString();
-            end = end ? end : (elementRange.end + (offset ? offset : 0)).toString();
+            start = start ? start : (elementRange.start + (offset ? offset : BigInt(0))).toString();
+            end = end ? end : (elementRange.end + (offset ? offset : BigInt(0))).toString();
             const tooltip = await this.tspDataProvider.fetchAnnotationTooltip(element, this.props.viewRange);
             if (start === end) {
                 return {
@@ -367,8 +367,8 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         const treeNodes = listToTree(this.state.timegraphTree, this.state.columns);
         const orderedTreeIds = getAllExpandedNodeIds(treeNodes, this.state.collapsedNodes);
         const length = range.end - range.start;
-        const overlap = ((length * 5) - length) / 2;
-        const start = range.start - overlap > 0 ? range.start - overlap : 0;
+        const overlap = ((length * BigInt(5)) - length) / BigInt(2);
+        const start = range.start - overlap > 0 ? range.start - overlap : BigInt(0);
         const end = range.end + overlap < this.props.unitController.absoluteRange ? range.end + overlap : this.props.unitController.absoluteRange;
         const newRange: TimelineChart.TimeGraphRange = { start, end };
         const newResolution: number = resolution * 0.8;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17260,9 +17260,9 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timeline-chart@next:
-  version "0.3.0-next.bbc0569.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.bbc0569.0.tgz#84bb7b8f4fdec85c97d8867858b7e8e03529604b"
-  integrity sha512-jRhJtvu/bUwqMAtbee39dKGb7tlG7FHYuGHQI6xxmMUXFq3988YDCnzTnnNPVsGFfNB5TD+7sAcvlKx0XO9c6g==
+  version "0.3.0-next.ed4042e.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.ed4042e.0.tgz#edfcec2a8cf3daa6b199b2d9d953b63360f9beea"
+  integrity sha512-P22wjcTzc1A9llEYQI6+26/DKchXQjAJhywY5XgCXCi722dzoOOrRAh18I5JU8/0vKxyhqqbgnH9Cis7xy48xA==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"
@@ -17467,9 +17467,9 @@ tslib@^2.2.0, tslib@^2.3.1:
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsp-typescript-client@next:
-  version "0.4.0-next.bf655d2"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.bf655d2.tgz#96f2dd888d8f862f1c7493caa1cfdcbac8e3ce8e"
-  integrity sha512-3urDVRBAvV95rMoRTH0fPEz5EbOZb8caAJh/TvXi1fuB/qiXeLtphgit8PZb227IQRKWSP4xBEZVm8fLA768UA==
+  version "0.4.0-next.ee6165e"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.ee6165e.tgz#e8f7c5aa1f4fdf30f9592ec6dd4e2a0685eb5ef4"
+  integrity sha512-YS73DH5Q+dxY4ggrAhuSC6IWnmtQaVu4p7wkJ+RGyq+EzfgxgbJvHkrrjAVOPDbaA6uPrg4R7GqSJdLgg64kTw==
   dependencies:
     node-fetch "^2.5.0"
 


### PR DESCRIPTION
Use type 'bigint' for all variables that are timestamps or durations.

Rename TimeRange.getstart() to getStart().

The minimum view range in XY chart and toolbar button zooming is set to
2 ns, to be able to zoom out of it and to always have at least one time
axis tick fully visible.

Fixes Issue #41

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>