### PR TITLE
Partial Gitpod fix: Add keytar (new Theia dependency)

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -11,6 +11,8 @@ RUN sudo apt-get update \
     && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 libgbm1 \
     # native-keymap
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
+    # keytar
+    && sudo apt-get install -y libsecret-1-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
 ENV NODE_VERSION="12.14.1"

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -13,6 +13,7 @@ RUN sudo apt-get update \
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
     # keytar
     && sudo apt-get install -y libsecret-1-dev \
+    # Clear package info (to free space)
     && sudo rm -rf /var/lib/apt/lists/*
 
 ENV NODE_VERSION="12.14.1"


### PR DESCRIPTION
This PR is only a partial fix because Gitpod breaks in two places right now:
- [x]  The build fails because keytar is missing. Fixed by this PR.
- [ ]  The frontend fails to connect to the server #488. @bhufmann will propose a solution to this by fixing #493

Details:
* Both issues (build fail, server connection fail) aren't present before the Theia version was upgraded.
* To observe the fontend not being able to connect to the server on Gitpod, you need to open this PR's branch (the extension doesn't build in Gitpod on the most recent version of master).

Commit a3a4002 "upgrade to Theia 1.17.0" in PR theia-ide#461 upgraded the version
of Theia used by the trace viewer extension. The new version of Theia
now requires keytar. This new dependency is missing in the gitpod setup
so the extension build fails in gitpod.

Update gitpod setup to install keytar (dependency) and fix gitpod
build.

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>