### PR TITLE
Add the shift-click selection interval in XY chart

### DIFF
--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -44,24 +44,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     private plugin = {
         afterDraw: (chartInstance: Chart, _easing: Chart.Easing, _options?: any) => { this.afterChartDraw(chartInstance); }
     };
-    private updateSelection = (event: MouseEvent) => {
-        const scale = this.props.viewRange.getEnd() - this.props.viewRange.getstart();
-        if (this.mouseIsDown && this.props.unitController.selectionRange && !this.isRightClick) {
-            const xStartPos = this.props.unitController.selectionRange.start;
-            let end = xStartPos + ((event.screenX - this.posPixelSelect) / this.lineChartRef.current.chartInstance.width) * scale;
-            end = Math.min(Math.max(end, 0), this.props.unitController.absoluteRange);
-            this.props.unitController.selectionRange = {
-                start: xStartPos,
-                end: end
-            };
-        }
-    };
 
     private endSelection = () => {
         if (this.isRightClick) {
            this.applySelectionZoom();
-        } else {
-            document.removeEventListener('mousemove', this.updateSelection);
         }
         this.mouseIsDown = false;
         document.removeEventListener('mouseup', this.endSelection);
@@ -342,11 +328,18 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             this.startPositionMouseRightClick = startTime;
         } else {
             this.isRightClick = false;
-            this.props.unitController.selectionRange = {
-                start: startTime,
-                end: startTime
-            };
-            document.addEventListener('mousemove', this.updateSelection);
+            if (event.shiftKey && this.props.unitController.selectionRange) {
+                this.props.unitController.selectionRange = {
+                    start: this.props.unitController.selectionRange.start,
+                    end: startTime
+                };
+            } else {
+                this.props.unitController.selectionRange = {
+                    start: startTime,
+                    end: startTime
+                };
+            }
+            this.onMouseMove(event);
         }
         document.addEventListener('mouseup', this.endSelection);
     }
@@ -436,9 +429,22 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         return xPos;
     }
 
+    private updateSelection(): void {
+        if (this.props.unitController.selectionRange){
+            const xStartPos = this.props.unitController.selectionRange.start;
+            this.props.unitController.selectionRange = {
+                start: xStartPos,
+                end: this.getTimeX(this.positionXMove)
+            };
+        }
+    }
+
     private onMouseMove(event: React.MouseEvent) {
         this.positionXMove = event.nativeEvent.offsetX;
         this.isMouseLeave = false;
+        if (this.mouseIsDown && !this.isRightClick) {
+            this.updateSelection();
+        }
         if (this.mouseIsDown && this.isRightClick) {
             this.forceUpdate();
         }
@@ -446,9 +452,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
 
     private onMouseLeave(event: React.MouseEvent) {
         this.isMouseLeave = true;
-        if (this.isRightClick) {
-            this.positionXMove = Math.max(0, Math.min(event.nativeEvent.offsetX, this.lineChartRef.current.chartInstance.width));
-            this.forceUpdate();
+        this.positionXMove = Math.max(0, Math.min(event.nativeEvent.offsetX, this.lineChartRef.current.chartInstance.width));
+        this.forceUpdate();
+        if (this.mouseIsDown && !this.isRightClick) {
+            this.updateSelection();
         }
     }
 


### PR DESCRIPTION
We can select interval with shift-click.

**Here is the result :**

![shiftclick](https://user-images.githubusercontent.com/83769103/134425487-1103c229-f9a7-4eb9-97f8-8a1927c62c0f.gif)

Fixes #439.

Signed-off-by: Ibrahim Fradj <ibrahim.fradj@ericsson.com>