### PR TITLE
Fix handling TRACE_SERVER_URL environment variable

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
@@ -47,6 +47,11 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
         this._experimentManager = this.props.tspClientProvider.getExperimentManager();
         this.props.tspClientProvider.addTspClientChangeListener(() => {
             this._experimentManager = this.props.tspClientProvider.getExperimentManager();
+            // new tsp-client connection... re-initialize the this widget and trac explorer
+            this.setState({ openedExperiments: [], selectedExperimentIndex: 0 });
+            this._selectedExperiment = undefined;
+            signalManager().fireOpenedTracesChangedSignal(new OpenedTracesUpdatedSignalPayload(0));
+            this.initialize();
         });
         this.state = { openedExperiments: [], selectedExperimentIndex: 0 };
     }

--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -35,6 +35,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         this._experimentManager = this.props.tspClientProvider.getExperimentManager();
         this.props.tspClientProvider.addTspClientChangeListener(() => {
             this._experimentManager = this.props.tspClientProvider.getExperimentManager();
+            this.setState({ availableOutputDescriptors: [] });
         });
         signalManager().on(Signals.EXPERIMENT_SELECTED, this.doHandleExperimentSelectedSignal);
         this.state = { availableOutputDescriptors: [] };

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-url-provider-frontend-impl.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-url-provider-frontend-impl.ts
@@ -21,6 +21,11 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
 
     ) {
         this.port = this.preferenceService.get(TRACE_PORT);
+        this._traceServerUrl = TRACE_SERVER_DEFAULT_URL.replace(/{}/g, this.port ? this.port : TRACE_SERVER_DEFAULT_PORT);
+        this._listeners = [];
+    }
+
+    async onStart(_app: FrontendApplication): Promise<void> {
         this.preferenceService.onPreferenceChanged(async event => {
             if (event.preferenceName === TRACE_PORT) {
                 try {
@@ -34,14 +39,7 @@ export class TraceServerUrlProviderImpl implements TraceServerUrlProvider, Front
                 this.updateListeners();
 
             }
-
         });
-
-        this._traceServerUrl = TRACE_SERVER_DEFAULT_URL.replace(/{}/g, this.port ? this.port : TRACE_SERVER_DEFAULT_PORT);
-        this._listeners = [];
-    }
-
-    async onStart(_app: FrontendApplication): Promise<void> {
         this._traceServerUrl = await this.traceViewerEnvironment.getTraceServerUrl();
         this.updateListeners();
     }

--- a/theia-extensions/viewer-prototype/src/common/trace-viewer-environment.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-viewer-environment.ts
@@ -17,23 +17,23 @@ export class TraceViewerEnvironment {
         @inject(MessageService) protected readonly messageService: MessageService) {
 
         this.port = this.preferenceService.get(TRACE_PORT);
-        this.preferenceService.onPreferenceChanged(async event => {
-            if (event.preferenceName === TRACE_PORT) {
-                try {
-                    await this.traceServerConfigService.stopTraceServer();
-                    this.messageService.info(`Trace server disconnected on port: ${this.port}.`);
-                } catch (e){
-                    // Do not show the error incase the user tries to modify the port before starting a server
-                }
-                this.port = event.newValue;
-                this._traceServerUrl = TRACE_SERVER_DEFAULT_URL.replace(/{}/g, this.port ? this.port : TRACE_SERVER_DEFAULT_PORT);
-            }
-        });
     }
 
     protected _traceServerUrl: string | undefined;
     async getTraceServerUrl(): Promise<string> {
         if (!this._traceServerUrl) {
+            this.preferenceService.onPreferenceChanged(async event => {
+                if (event.preferenceName === TRACE_PORT) {
+                    try {
+                        await this.traceServerConfigService.stopTraceServer();
+                        this.messageService.info(`Trace server disconnected on port: ${this.port}.`);
+                    } catch (e){
+                        // Do not show the error incase the user tries to modify the port before starting a server
+                    }
+                    this.port = event.newValue;
+                    this._traceServerUrl = TRACE_SERVER_DEFAULT_URL.replace(/{}/g, this.port ? this.port : TRACE_SERVER_DEFAULT_PORT);
+                }
+            });
             const traceServerUrl = await this.environments.getValue('TRACE_SERVER_URL');
             this._traceServerUrl = traceServerUrl ? this.parseUrl(traceServerUrl.value || TRACE_SERVER_DEFAULT_URL) : TRACE_SERVER_DEFAULT_URL;
         }


### PR DESCRIPTION
Fix handling TRACE_SERVER_URL environment variable

- Make sure that switch over to the TRACE_SERVER_URL updates relevant  widgets
- Adding preference listener was moved to allow reading the environment variable TRACE_SERVER_URL before resetting the connection

Fixes #493

Note: This change doesn't change the behaviour, that the default URL is used to initialize the all the views. In order to fix that, the start-up procedure of the theia-trace-extension has to be overhauled.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>
