### PR TITLE
Add zoom shortcut +/- for TIMEGRAPH and XY CHART

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -273,10 +273,27 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     render(): JSX.Element {
-        return <div className='trace-context-container' ref={this.traceContextContainer}>
+        return <div className='trace-context-container'
+                onKeyDown={event => this.onKeyDown(event)}
+                ref={this.traceContextContainer}>
             <TooltipComponent ref={this.tooltipComponent} />
             {this.props.outputs.length ? this.renderOutputs() : this.renderPlaceHolder()}
         </div>;
+    }
+
+    private onKeyDown(key: React.KeyboardEvent) {
+        switch (key.key) {
+            case '+':
+            case '=': {
+                this.zoomButton(true);
+                break;
+            }
+            case '-':
+            case '_': {
+                this.zoomButton(false);
+                break;
+            }
+        }
     }
 
     private renderOutputs() {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -12,7 +12,6 @@ import { EntryTree } from './utils/filtrer-tree/entry-tree';
 import { getAllExpandedNodeIds } from './utils/filtrer-tree/utils';
 import { TreeNode } from './utils/filtrer-tree/tree-node';
 import ColumnHeader from './utils/filtrer-tree/column-header';
-import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 
 type XYOuputState = AbstractOutputState & {
     selectedSeriesId: number[];
@@ -490,16 +489,6 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
                 case 'l':
                 case 'ArrowRight': {
                     this.pan(PAN_RIGHT);
-                    break;
-                }
-                case '+':
-                case '=': {
-                    signalManager().fireZoomTimeGraphSignal(true);
-                    break;
-                }
-                case '-':
-                case '_': {
-                    signalManager().fireZoomTimeGraphSignal(false);
                     break;
                 }
             }


### PR DESCRIPTION
We can now zoom with +/- or =/_ in timegraph and xy chart.

Signed-off-by: Ibrahim Fradj <ibrahim.fradj@ericsson.com>