### PR TITLE
Release activities for v0.1.0

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "browser-theia-trace-example-app",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "theia": {
     "target": "browser",
     "frontend": {
@@ -9,29 +9,28 @@
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
           "editor.autoSave": "on",
-          "trace-viewer.path" : "../../trace-compass-server/tracecompass-server",
-          "trace-viewer.port" : 8080
-
+          "trace-viewer.path": "../../trace-compass-server/tracecompass-server",
+          "trace-viewer.port": 8080
         }
       }
     }
   },
   "dependencies": {
     "@theia/core": "1.17.2",
+    "@theia/editor": "1.17.2",
     "@theia/filesystem": "1.17.2",
-    "@theia/workspace": "1.17.2",
-    "@theia/preferences": "1.17.2",
+    "@theia/getting-started": "1.17.2",
+    "@theia/keymaps": "1.17.2",
+    "@theia/markers": "1.17.2",
+    "@theia/messages": "1.17.2",
+    "@theia/monaco": "1.17.2",
     "@theia/navigator": "1.17.2",
+    "@theia/preferences": "1.17.2",
     "@theia/process": "1.17.2",
     "@theia/terminal": "1.17.2",
-    "@theia/editor": "1.17.2",
-    "@theia/markers": "1.17.2",
-    "@theia/monaco": "1.17.2",
-    "@theia/messages": "1.17.2",
     "@theia/vsx-registry": "1.17.2",
-    "@theia/keymaps": "1.17.2",
-    "@theia/getting-started": "1.17.2",
-    "theia-traceviewer": "0.0.1"
+    "@theia/workspace": "1.17.2",
+    "theia-traceviewer": "0.1.0"
   },
   "devDependencies": {
     "@theia/cli": "1.17.2"

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -5,7 +5,7 @@
   "build": {
     "electronVersion": "9.1.2"
   },
-  "version": "0.0.1",
+  "version": "0.1.0",
   "theia": {
     "target": "electron",
     "backend": {
@@ -18,29 +18,29 @@
         "applicationName": "Theia-Trace Example Application",
         "preferences": {
           "editor.autoSave": "on",
-          "trace-viewer.path" : "../../trace-compass-server/tracecompass-server",
-          "trace-viewer.port" : 8080
+          "trace-viewer.path": "../../trace-compass-server/tracecompass-server",
+          "trace-viewer.port": 8080
         }
       }
     }
   },
   "dependencies": {
     "@theia/core": "1.17.2",
+    "@theia/editor": "1.17.2",
+    "@theia/electron": "1.17.2",
     "@theia/filesystem": "1.17.2",
-    "@theia/workspace": "1.17.2",
-    "@theia/preferences": "1.17.2",
+    "@theia/getting-started": "1.17.2",
+    "@theia/keymaps": "1.17.2",
+    "@theia/markers": "1.17.2",
+    "@theia/messages": "1.17.2",
+    "@theia/monaco": "1.17.2",
     "@theia/navigator": "1.17.2",
+    "@theia/preferences": "1.17.2",
     "@theia/process": "1.17.2",
     "@theia/terminal": "1.17.2",
-    "@theia/editor": "1.17.2",
-    "@theia/markers": "1.17.2",
-    "@theia/monaco": "1.17.2",
-    "@theia/messages": "1.17.2",
     "@theia/vsx-registry": "1.17.2",
-    "@theia/keymaps": "1.17.2",
-    "@theia/getting-started": "1.17.2",
-    "@theia/electron": "1.17.2",
-    "theia-traceviewer": "0.0.1"
+    "@theia/workspace": "1.17.2",
+    "theia-traceviewer": "0.1.0"
   },
   "devDependencies": {
     "@theia/cli": "1.17.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "4.0.0",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "dependencies": {
-    "tsp-typescript-client": "next"
+    "tsp-typescript-client": "^0.3.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traceviewer-base",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Trace Viewer base package, contains trace management utilities",
   "license": "MIT",
   "repository": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "dependencies": {
-    "tsp-typescript-client": "^0.3.0"
+    "tsp-typescript-client": "next"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traceviewer-react-components",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Trace Compass react components",
   "license": "MIT",
   "repository": {
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.17",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "traceviewer-base": "0.0.1",
+    "traceviewer-base": "0.1.0",
     "ag-grid-community": "^23.1.0",
     "ag-grid-react": "^23.1.0",
     "chart.js": "^2.8.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -28,8 +28,8 @@
     "react-virtualized": "^9.21.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.86.0",
-    "timeline-chart": "^0.2.0",
-    "tsp-typescript-client": "^0.3.0"
+    "timeline-chart": "next",
+    "tsp-typescript-client": "next"
   },
   "devDependencies": {
     "@testing-library/react": "^10.4.6",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -28,8 +28,8 @@
     "react-virtualized": "^9.21.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.86.0",
-    "timeline-chart": "next",
-    "tsp-typescript-client": "next"
+    "timeline-chart": "^0.2.0",
+    "tsp-typescript-client": "^0.3.0"
   },
   "devDependencies": {
     "@testing-library/react": "^10.4.6",

--- a/theia-extensions/viewer-prototype/package.json
+++ b/theia-extensions/viewer-prototype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-traceviewer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Trace Viewer Theia Extension",
   "keywords": [
     "theia-extension"
@@ -18,8 +18,8 @@
     "@theia/core": "1.17.2",
     "@theia/editor": "1.17.2",
     "@theia/filesystem": "1.17.2",
-    "traceviewer-base": "0.0.1",
-    "traceviewer-react-components": "0.0.1",
+    "traceviewer-base": "0.1.0",
+    "traceviewer-react-components": "0.1.0",
     "tree-kill": "latest"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17259,10 +17259,10 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-timeline-chart@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0.tgz#d8af26c4cd632a0c17ecc619518d273176287ef5"
-  integrity sha512-bA8Oo3dD1troe2VpcaGh4B64umcEeF0eBr5+lHdf37wmw8KPUUNrKLBhhFmWBdVoVMh850Y+FW7qtnk72WPntA==
+timeline-chart@next:
+  version "0.3.0-next.bbc0569.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.3.0-next.bbc0569.0.tgz#84bb7b8f4fdec85c97d8867858b7e8e03529604b"
+  integrity sha512-jRhJtvu/bUwqMAtbee39dKGb7tlG7FHYuGHQI6xxmMUXFq3988YDCnzTnnNPVsGFfNB5TD+7sAcvlKx0XO9c6g==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"
@@ -17466,10 +17466,10 @@ tslib@^2.2.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tsp-typescript-client@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.3.0.tgz#6cfd075f219e2338a6e6d5e0aa9f329188e29171"
-  integrity sha512-JVG3dlFAU7vd0NvlY1xLb54R3MUavX5mYe6r26DiZqg5+BUbEW3s0B4eAs3ebueGIUAr1P+NjcsTzJfWtdcbMg==
+tsp-typescript-client@next:
+  version "0.4.0-next.bf655d2"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.4.0-next.bf655d2.tgz#96f2dd888d8f862f1c7493caa1cfdcbac8e3ce8e"
+  integrity sha512-3urDVRBAvV95rMoRTH0fPEz5EbOZb8caAJh/TvXi1fuB/qiXeLtphgit8PZb227IQRKWSP4xBEZVm8fLA768UA==
   dependencies:
     node-fetch "^2.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17259,10 +17259,10 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
-timeline-chart@next:
-  version "0.2.0-next.3363469.0"
-  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0-next.3363469.0.tgz#bc760f6b06c8f86813985db85f74853374aade00"
-  integrity sha512-ZoL8hnyX8D4LwCUPGn91DGzI15Tv6sRcHReuj2K35BfAbuvg9bh9b8QuDF/Khv7k/ZGTp0E1Quv3LtSPlQvBBg==
+timeline-chart@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/timeline-chart/-/timeline-chart-0.2.0.tgz#d8af26c4cd632a0c17ecc619518d273176287ef5"
+  integrity sha512-bA8Oo3dD1troe2VpcaGh4B64umcEeF0eBr5+lHdf37wmw8KPUUNrKLBhhFmWBdVoVMh850Y+FW7qtnk72WPntA==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"
@@ -17466,10 +17466,10 @@ tslib@^2.2.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tsp-typescript-client@next:
-  version "0.2.0-next.33d243c"
-  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.2.0-next.33d243c.tgz#4454fc9ee3b1594b7f6ec7d83d0760ccc569542c"
-  integrity sha512-eDNAyCS+Sh0DLgRuXdLuQI4asj1JmfvUd2yGYJdszl0QbiiDZ2FK79I1/0UwjOheXVzRVSb+aPeGw6b3A4sOvw==
+tsp-typescript-client@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tsp-typescript-client/-/tsp-typescript-client-0.3.0.tgz#6cfd075f219e2338a6e6d5e0aa9f329188e29171"
+  integrity sha512-JVG3dlFAU7vd0NvlY1xLb54R3MUavX5mYe6r26DiZqg5+BUbEW3s0B4eAs3ebueGIUAr1P+NjcsTzJfWtdcbMg==
   dependencies:
     node-fetch "^2.5.0"
 


### PR DESCRIPTION
This pull request provides commits done for the v0.1.0 release of `theia-traceviewer`, `traceviewer-base` and `traceviewer-react-components` to NPM .

The release builds used `timeline-chart` `v0.2.0` and `tsp-typescript-client` `v0.3.0`.

The last commit then will make sure that version next of these libraries are pulled-in during a build. 

Once this pull-request is merged I'll upload the tag `v0.1.0` on the commit with message `v0.1.0`. 