### PR TITLE
Remove scatter data providers (latency scatter charts)

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -164,7 +164,17 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         if (descriptors && descriptors.length) {
             outputDescriptors.push(...descriptors);
         }
-        return outputDescriptors.filter(value => value.type !== 'DATA_TREE');
+        /**
+         * Remove outputs of type DATA_TREE since the view is not supported in theia-traceviewer
+         */
+        let outputs = outputDescriptors.filter(value => (value.type !== 'DATA_TREE'));
+        /*
+         * Remove certain scatter specific outputs since they are not supported in the theia-traceviewer
+         * There is no generic way to identify such outputs. This is not ideal because other server
+         * implementations are not covered.
+         */
+        outputs = outputs.filter(value => !value.id.includes('scatter'));
+        return outputs;
     }
 }
 


### PR DESCRIPTION
All latency scatter XY charts have in common that each series don't
have a common x axis in comparison to the Histogram which have multiple
series where each series have the same x values the same number of
y-values.

The theia-traceviewer currently doesn't have support of drawing such
scatter charts properly and should be hidden.

The data provider descriptor, however, doesn't provide a way to
determine if it's a xy-chart with common x-Axis or not, and hence it's
not possible to generically hide such graphs.

This PR hides such graphs based on the data provider ID, which contain
the string "scatter" in it the Trace Compass case all with
org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.scatter.dataprovider.

Even if this is Trace Compass server specific, it will improve
the UX for such users. This stop gap implementation will be removed
once the front-end properly supports such graphs or there is a generic
way to filter-out unwanted data provider.

Contributes to fixing of #296

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>