### PR TITLE
Rename signals for zoom-in, zoom-out & reset zoom and related methods

### DIFF
--- a/packages/base/src/signals/signal-manager.ts
+++ b/packages/base/src/signals/signal-manager.ts
@@ -16,8 +16,8 @@ export declare interface SignalManager {
     fireSelectionChangedSignal(payload: { [key: string]: string }): void;
     fireCloseTraceViewerTabSignal(traceUUID: string): void;
     fireTraceViewerTabActivatedSignal(experiment: Experiment): void;
-    fireZoomTimeGraphSignal(hasZoomedIn: boolean): void;
-    fireResetTimeGraphSignal(): void;
+    fireUpdateZoomSignal(hasZoomedIn: boolean): void;
+    fireResetZoomSignal(): void;
     fireAnnotationFilterSignal(annotationMarkers?: string[]): void;
     fireAnnotationsFetchedSignal(annotationCategories: string[]): void;
 }
@@ -36,8 +36,8 @@ export const Signals = {
     SELECTION_CHANGED: 'selection changed',
     CLOSE_TRACEVIEWERTAB: 'tab closed',
     TRACEVIEWERTAB_ACTIVATED: 'widget activated',
-    TIMEGRAPH_ZOOMED: 'timegraph zoomed',
-    TIMEGRAPH_RESET: 'timegraph reset',
+    UPDATE_ZOOM: 'update zoom',
+    RESET_ZOOM: 'reset zoom',
     ANNOTATION_MARKERS_FILTERED: 'filter marker category',
     ANNOTATIONS_FETCHED: 'annotations fetched'
 };
@@ -79,11 +79,11 @@ export class SignalManager extends EventEmitter implements SignalManager {
     fireTraceViewerTabActivatedSignal(experiment: Experiment): void {
         this.emit(Signals.TRACEVIEWERTAB_ACTIVATED, experiment);
     }
-    fireZoomTimeGraphSignal(hasZoomedIn: boolean): void {
-        this.emit(Signals.TIMEGRAPH_ZOOMED, hasZoomedIn);
+    fireUpdateZoomSignal(hasZoomedIn: boolean): void {
+        this.emit(Signals.UPDATE_ZOOM, hasZoomedIn);
     }
-    fireResetTimeGraphSignal(): void {
-        this.emit(Signals.TIMEGRAPH_RESET);
+    fireResetZoomSignal(): void {
+        this.emit(Signals.RESET_ZOOM);
     }
     fireAnnotationFilterSignal(annotationMarkers?: string[]): void {
         this.emit(Signals.ANNOTATION_MARKERS_FILTERED, annotationMarkers);

--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -78,8 +78,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         }
     };
 
-    private onTimeGraphZoomed = (hasZoomedIn: boolean) => this.doHandleTimeGraphZoomedSignal(hasZoomedIn);
-    private onTimeGraphReset = () => this.doHandleTimeGraphResetSignal();
+    private onUpdateZoom = (hasZoomedIn: boolean) => this.doHandleUpdateZoomSignal(hasZoomedIn);
+    private onResetZoom = () => this.doHandleResetZoomSignal();
 
     constructor(props: TraceContextProps) {
         super(props);
@@ -127,8 +127,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         this.traceContextContainer = React.createRef();
         this.initialize();
         signalManager().on(Signals.THEME_CHANGED, this.onBackgroundThemeUpdated);
-        signalManager().on(Signals.TIMEGRAPH_ZOOMED, this.onTimeGraphZoomed);
-        signalManager().on(Signals.TIMEGRAPH_RESET, this.onTimeGraphReset);
+        signalManager().on(Signals.UPDATE_ZOOM, this.onUpdateZoom);
+        signalManager().on(Signals.RESET_ZOOM, this.onResetZoom);
     }
 
     private updateBackgroundTheme(theme: string): void {
@@ -197,8 +197,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         this.props.messageManager.removeStatusMessage(this.INDEXING_STATUS_BAR_KEY);
         this.props.messageManager.removeStatusMessage(this.TIME_SELECTION_STATUS_BAR_KEY);
         this.props.removeResizeHandler(this.onResize);
-        signalManager().off(Signals.TIMEGRAPH_ZOOMED, this.onTimeGraphZoomed);
-        signalManager().off(Signals.TIMEGRAPH_RESET, this.onTimeGraphReset);
+        signalManager().off(Signals.UPDATE_ZOOM, this.onUpdateZoom);
+        signalManager().off(Signals.RESET_ZOOM, this.onResetZoom);
     }
 
     async componentDidUpdate(): Promise<void> {
@@ -206,11 +206,11 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         ReactTooltip.rebuild();
     }
 
-    private doHandleTimeGraphZoomedSignal(hasZoomedIn: boolean) {
+    private doHandleUpdateZoomSignal(hasZoomedIn: boolean) {
         this.zoomButton(hasZoomedIn);
     }
 
-    private doHandleTimeGraphResetSignal() {
+    private doHandleResetZoomSignal() {
         this.unitController.viewRange = { start: 0, end: this.unitController.absoluteRange };
     }
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -45,21 +45,21 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             TraceViewerToolbarCommands.ZOOM_IN, {
             isVisible: (w: Widget) => w instanceof TraceViewerWidget,
             execute: () => {
-                signalManager().fireZoomTimeGraphSignal(true);
+                signalManager().fireUpdateZoomSignal(true);
             }
         });
         registry.registerCommand(
             TraceViewerToolbarCommands.ZOOM_OUT, {
             isVisible: (w: Widget) => w instanceof TraceViewerWidget,
             execute: () => {
-                signalManager().fireZoomTimeGraphSignal(false);
+                signalManager().fireUpdateZoomSignal(false);
             }
         });
         registry.registerCommand(
             TraceViewerToolbarCommands.RESET, {
             isVisible: (w: Widget) => w instanceof TraceViewerWidget,
             execute: () => {
-                signalManager().fireResetTimeGraphSignal();
+                signalManager().fireResetZoomSignal();
             }
         });
     }


### PR DESCRIPTION
Initially the zooming capability was only supported for time graphs and it made somewhat sense to reference 'timegraph' in the names. However, after supporting it globally it's better to use generic names.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>