### PR TITLE
Fix endless loop when opening certain XY Charts.

### DIFF
--- a/packages/react-components/src/components/utils/filtrer-tree/utils.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/utils.tsx
@@ -31,7 +31,9 @@ export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] =
         if ((entry.parentId !== undefined) && (entry.parentId !== -1)) {
             const parent: TreeNode = lookup[entry.parentId];
             if (parent) {
-                parent.children.push(node);
+                if (parent.id !== node.id) {
+                    parent.children.push(node);
+                }
             } else {
                 // no parent available, treat is as root node
                 node.isRoot = true;


### PR DESCRIPTION
Don't allow children nodes with same ID as parent when creating the
XY tree.

Fixes #513

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>