### PR TITLE
Output container resize handlers visible in dark theme

### DIFF
--- a/packages/react-components/style/trace-context-style.css
+++ b/packages/react-components/style/trace-context-style.css
@@ -30,3 +30,8 @@
     width: 10px !important;
     height: 10px !important;
 }
+
+.react-grid-item > .react-resizable-handle::after {
+    border-right-color: var(--theia-ui-font-color0) !important;
+    border-bottom-color: var(--theia-ui-font-color0) !important;
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -104,7 +104,7 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
                     let index = 0;
                     const traceViewerWidget = widget as TraceViewerWidget;
                     const markerCategories = traceViewerWidget.getMarkerCategories();
-                    markerCategories.forEach((categoryInfo, categoryName, self) => {
+                    markerCategories.forEach((categoryInfo, categoryName) => {
                         const toggleInd = categoryInfo.toggleInd;
                         index += 1;
                         toDisposeOnHide.push(this.menus.registerMenuAction(menuPath, {


### PR DESCRIPTION
Fixes #531 
Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>

Resize handlers are visible
![Screen Shot 2021-10-27 at 2 08 54 PM](https://user-images.githubusercontent.com/92893187/139131088-430b9224-a587-44e1-914e-ec69947c89b3.png)
![Screen Shot 2021-10-27 at 2 08 37 PM](https://user-images.githubusercontent.com/92893187/139131100-126d4a28-1ca6-425a-b6e5-092a29b18cd3.png)

