### PR TITLE
Add overflow ellipses and tooltips to Available Views list

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -90,6 +90,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
             traceContainerClassName = traceContainerClassName + ' theia-mod-selected';
         }
         return <div className={traceContainerClassName}
+            title={outputName + ':\n' + outputDescription}
             id={`${traceContainerClassName}-${props.index}`}
             key={props.key}
             style={props.style}
@@ -137,7 +138,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
     protected doExperimentSelected(experiment: Experiment | undefined): void {
         if (this._selectedExperiment?.UUID !== experiment?.UUID) {
             this._selectedExperiment = experiment;
-            this.setState({availableOutputDescriptors: []});
+            this.setState({ availableOutputDescriptors: [] });
             this.updateAvailableViews();
         }
     }

--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -74,12 +74,16 @@
 }
 
 .trace-element-name, .outputs-element-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-weight: bold;
     margin: unset;
     height: var(--trace-extension-list-line-height);
 }
 
 .trace-element-path-container, .outputs-element-description {
+    overflow: hidden;
+    text-overflow: ellipsis;
     margin: unset;
     color: var(--theia-ui-font-color2);
     /* color: rgb(160, 160, 160); */


### PR DESCRIPTION
fixes #507

Among all available views, if there is a text-overflow for name or description, the extra letters are replaced with ellipses.
When the width of the sidebar changes, the ellipses will be replaced with letters until the end of the string.
Also, if the mouse hovers on a view, the tooltip will display the view name and view description simultaneously.

Signed-off-by: yining wang <yining.wang@ericsson.com
<img width="349" alt="Screen Shot 2021-10-27 at 2 00 20 PM" src="https://user-images.githubusercontent.com/92875879/139454633-0b3cd703-2c30-42b2-9c01-c1290e15b680.png">
>