### PR TITLE
Add support for regular expression matching in Events table search

### DIFF
--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -490,7 +490,7 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             this.gridApi.forEachNode(rowNode => {
                 let isMatched = true;
                 this.filterModel.forEach((value, key) => {
-                    if (!rowNode.data[key].includes(value)) {
+                    if ((rowNode.data[key].search(new RegExp(value)) === -1)) {
                         isMatched = false;
                     }
                 });

--- a/packages/react-components/src/components/table-renderer-components.tsx
+++ b/packages/react-components/src/components/table-renderer-components.tsx
@@ -42,7 +42,7 @@ export class CellRenderer extends React.Component<CellRendererProps> {
         if (this.props.filterModel.size > 0) {
             if (isMatched) {
                 cellElement = <>
-                    {currFieldVal.split(searchTerm).map((tag: string, index: number, array: string[]) =>
+                    {currFieldVal.split(new RegExp(searchTerm)).map((tag: string, index: number, array: string[]) =>
                         <span key={index.toString()}>
                             <>
                                 {tag}
@@ -50,7 +50,7 @@ export class CellRenderer extends React.Component<CellRendererProps> {
                             <>
                                 {
                                     index < array.length - 1 ?
-                                        <span style={{ backgroundColor: this.props.searchResultsColor }}>{searchTerm}</span>
+                                        <span style={{ backgroundColor: this.props.searchResultsColor }}>{currFieldVal.match(new RegExp(searchTerm))[0]}</span>
                                         : <></>
                                 }
                             </>


### PR DESCRIPTION
fixes #410

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>

Example 1 - Search for substring (all matches for "sc"):
![Screen Shot 2021-11-01 at 10 32 58 AM](https://user-images.githubusercontent.com/92893187/139703151-a147687d-9b00-4e36-8eac-a2920bd90b7a.png)

Example 2 - Search for regular expression (strings that start with "sc"):
![Screen Shot 2021-11-01 at 10 33 11 AM](https://user-images.githubusercontent.com/92893187/139703285-7d4f6bd6-021d-452a-b333-22e2e4ed390b.png)


