### PR TITLE
Clarify trace server settings labels

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
@@ -1,8 +1,8 @@
 import { PreferenceSchema, PreferenceProxy, PreferenceScope } from '@theia/core/lib/browser';
 import { TRACE_SERVER_DEFAULT_PORT } from '../common/trace-server-url-provider';
 
-export const TRACE_PATH = 'trace Viewer.path';
-export const TRACE_PORT = 'trace Viewer.port';
+export const TRACE_PATH = 'trace Viewer.trace Server.path';
+export const TRACE_PORT = 'trace Viewer.trace Server.port';
 
 export const ServerSchema: PreferenceSchema = {
     scope: PreferenceScope.Folder,

--- a/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
@@ -1,8 +1,8 @@
 import { PreferenceSchema, PreferenceProxy, PreferenceScope } from '@theia/core/lib/browser';
 import { TRACE_SERVER_DEFAULT_PORT } from '../common/trace-server-url-provider';
 
-export const TRACE_PATH = 'trace-viewer.path';
-export const TRACE_PORT = 'trace-viewer.port';
+export const TRACE_PATH = 'trace Viewer.path';
+export const TRACE_PORT = 'trace Viewer.port';
 
 export const ServerSchema: PreferenceSchema = {
     scope: PreferenceScope.Folder,


### PR DESCRIPTION
fixes #355 

The format of trace-server preference is now consistent with other related settings.

Signed-off-by: Yining Wang <yining.wang@ericsson.com>