### PR TITLE
Add overflow ellipsis and tooltips to output title-bar

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -85,7 +85,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <button className='remove-component-button' onClick={this.closeComponent}>
                 <FontAwesomeIcon icon={faTimes} />
             </button>
-            <div className='title-bar-label'>
+            <div className='title-bar-label' title={outputName}>
                 {outputName}
             </div>
         </React.Fragment>;

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -17,12 +17,14 @@
     text-align: center;
     writing-mode: vertical-rl;
     height: 100%;
-    min-height: 150px;
     transform: rotate(180deg);
     user-select: none;
     align-self: center;
     justify-self: center;
     cursor: move;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .remove-component-button {
     background: none;


### PR DESCRIPTION
fixes #537

avoids title-bar texts being mixed and makes diagrams more readable

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>

3 output views opened and resized to their min-height:
![Screen Shot 2021-11-02 at 1 47 05 PM](https://user-images.githubusercontent.com/92893187/139931609-c1b0c799-4bbb-4be4-b11d-0dff791ade7a.png)


