### PR TITLE
Ability to clear list of analysis when no trace is selected (and open)

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget.tsx
@@ -77,6 +77,8 @@ export class TraceExplorerOpenedTracesWidget extends ReactWidget {
                 tspClientProvider={this.tspClientProvider}
                 contextMenuRenderer={(event, experiment) => this.doHandleContextMenuEvent(event, experiment) }
                 onClick={(event, experiment) => this.doHandleClickEvent(event, experiment) }
+                widgetManager={this.widgetManager}
+                traceViewerWidgetID={TraceViewerWidget.ID}
             ></ReactOpenTracesWidget>
             }
         </div>);

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-views-widget.tsx
@@ -1,8 +1,9 @@
 import { inject, injectable, postConstruct } from 'inversify';
-import { ReactWidget, Widget, Message } from '@theia/core/lib/browser';
+import { ReactWidget, Widget, Message, WidgetManager } from '@theia/core/lib/browser';
 import { TspClientProvider } from '../../tsp-client-provider-impl';
 import * as React from 'react';
 import { ReactAvailableViewsWidget} from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-views-widget';
+import { TraceViewerWidget } from '../../trace-viewer/trace-viewer';
 
 @injectable()
 export class TraceExplorerViewsWidget extends ReactWidget {
@@ -10,6 +11,7 @@ export class TraceExplorerViewsWidget extends ReactWidget {
     static LABEL = 'Available Views';
 
     @inject(TspClientProvider) protected readonly tspClientProvider!: TspClientProvider;
+    @inject(WidgetManager) protected readonly widgetManager!: WidgetManager;
 
     @postConstruct()
     init(): void {
@@ -28,6 +30,8 @@ export class TraceExplorerViewsWidget extends ReactWidget {
                 id={this.id}
                 title={this.title.label}
                 tspClientProvider={this.tspClientProvider}
+                widgetManager={this.widgetManager}
+                traceViewerWidgetID={TraceViewerWidget.ID}
             ></ReactAvailableViewsWidget>
             }
         </div>);

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer.tsx
@@ -20,6 +20,7 @@ import { TraceExplorerContribution } from '../trace-explorer/trace-explorer-cont
 import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
 import { BackendFileService } from '../../common/backend-file-service';
 import { CancellationTokenSource } from '@theia/core';
+import { OpenedTracesUpdatedSignalPayload } from 'traceviewer-base/lib/signals/opened-traces-updated-signal-payload';
 
 export const TraceViewerWidgetOptions = Symbol('TraceViewerWidgetOptions');
 export interface TraceViewerWidgetOptions {
@@ -239,9 +240,11 @@ export class TraceViewerWidget extends ReactWidget {
         }
     }
 
-    onCloseRequest(msg: Message): void {
+    async onCloseRequest(msg: Message): Promise<void> {
         this.statusBar.removeElement('time-selection-range');
         super.onCloseRequest(msg);
+        const remoteExperiments = await this.experimentManager.getOpenedExperiments();
+        signalManager().fireOpenedTracesChangedSignal(new OpenedTracesUpdatedSignalPayload(remoteExperiments ? remoteExperiments.length : 0));
     }
 
     onAfterShow(msg: Message): void {


### PR DESCRIPTION
fixes #489 

- When no trace tabs are open the available views section is empty:
![Screen Shot 2021-11-09 at 10 08 10 AM](https://user-images.githubusercontent.com/92893187/140960782-c99f7cb2-12d5-4527-bd34-ca1e4f4737ea.png)

Fix:
- Whenever a trace tab is closed fire a signal to trace-explorer-views-widget which checks the number of open tabs. If none, it will clear available views
- Then update available views for the selected experiment only if trace tabs are open