### PR TITLE
XY Charts, Timegraph, Table: Display message when analysis fails

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -109,4 +109,12 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     }
 
     abstract renderMainArea(): React.ReactNode;
+
+    protected analysisFailedMessage(): React.ReactFragment {
+        return <React.Fragment>
+            <div className='analysis-failed-message'>
+                Trace analysis failed.
+            </div>
+        </React.Fragment>;
+    }
 }

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -4,6 +4,10 @@ import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/respon
 
 export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
     renderMainArea(): React.ReactNode {
+        if (this.state.outputStatus === ResponseStatus.FAILED) {
+            return this.analysisFailedMessage();
+        }
+
         // Make tree thiner when chart has a y-axis
         const yAxisBuffer = this.props.outputDescriptor.type === 'TREE_TIME_XY' ? this.props.style.yAxisWidth: 0;
         const treeWidth = this.getMainAreaWidth() - this.props.style.chartWidth - yAxisBuffer;

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -186,11 +186,18 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 this.setState({
                     outputStatus: treeResponse.status,
                     timegraphTree: treeResponse.model.entries,
-                    columns,
+                    columns
                 }, this.updateTotalHeight);
+            } else {
+                this.setState({
+                    outputStatus: treeResponse.status
+                });
             }
             return treeResponse.status;
         }
+        this.setState({
+            outputStatus: ResponseStatus.FAILED
+        });
         return ResponseStatus.FAILED;
     }
 

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -122,6 +122,9 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
             }
             return treeResponse.status;
         }
+        this.setState({
+            outputStatus: ResponseStatus.FAILED
+        });
         return ResponseStatus.FAILED;
     }
 

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -286,14 +286,14 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     }
 
     renderChart(): React.ReactNode {
-        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0 ) {
+        // width={this.props.style.chartWidth}
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0) {
             return <React.Fragment>
-                {
-                    <p className='no-data' style={{fontSize: 20, marginRight: '5px', marginLeft: '5px', justifyContent:'center', alignItems:'center'}}>
-                        Trace analysis completed.
-                        No results: Trace missing required events.
-                    </p>
-                }
+                <div className='no-data'>
+                    Trace analysis completed.
+                    <br />
+                    No results: Trace missing required events.
+                </div>
             </React.Fragment>;
         }
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length===0 ) {

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -97,6 +97,14 @@ canvas {
     align-self: center;
 }
 
+.analysis-failed-message {
+    font-size: 20px;
+    margin-top: -20px; /* So text is vertically aligned relative to its center rather than its top */
+    transform: translate(0, 50%);
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .table-tree {
     display: grid;
     border-collapse: collapse;


### PR DESCRIPTION
# Contents
* **Commits 1-4:** Code and styling cleanup for "no results" message added by #447 (with my limited HTML knowledge)
* **Commits 5-7:** For the XY, Timegraph and Table output components, add message for when the analysis fails:
  * Output status is always set: When the TSP response is bad, and in all cases when the TSP response is good
  * "Analysis failed" message displays when the status is FAILED

Because there's a lot of cleanup and changes in several files I recommend looking at the commits separately.

# Main change

Currently, if the analysis fails (i.e. outputStatus is FAILED) then the
analysis's view panel never updates and shows "Analysis running" forever
even though the server has responded.

Show a message to tell the user the analysis has failed.

Contributes towards fixing #460

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>

# Testing
The code was tested by setting the message to display when the analysis returned the status 'RUNNING' instead of when the analysis returned 'FAILED' and the message displayed correctly.

![image](https://user-images.githubusercontent.com/28311615/143127480-57ce7383-2c0a-44b1-ba66-de2f00330c5e.png)