### PR TITLE
Issue/479 specify server cli arguments

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-server-preference.ts
@@ -1,8 +1,9 @@
 import { PreferenceSchema, PreferenceProxy, PreferenceScope } from '@theia/core/lib/browser';
-import { TRACE_SERVER_DEFAULT_PORT } from '../common/trace-server-url-provider';
+import { TRACE_VIEWER_DEFAULT_PORT } from '../common/trace-server-url-provider';
 
-export const TRACE_PATH = 'traceViewer.traceServer.path';
-export const TRACE_PORT = 'traceViewer.traceServer.port';
+export const TRACE_PATH = 'trace Viewer.trace Server.path';
+export const TRACE_PORT = 'trace Viewer.trace Viewer.port';
+export const TRACE_ARGS = 'trace Viewer.trace Server.arguments';
 
 export const ServerSchema: PreferenceSchema = {
     scope: PreferenceScope.Folder,
@@ -14,8 +15,14 @@ export const ServerSchema: PreferenceSchema = {
         },
         [TRACE_PORT]: {
             type: 'integer',
-            default: TRACE_SERVER_DEFAULT_PORT,
-            description: 'Specify the port on which you want to execute the server. This change will take effect the next time you open a trace',
+            default: TRACE_VIEWER_DEFAULT_PORT,
+            description: 'Specify the port the Trace Viewer would use to connect to the trace server',
+        },
+        [TRACE_ARGS]: {
+            type: 'string',
+            default: '',
+            description: 'Specify trace-server command line arguments. This change will take effect the next time the trace server starts.'+'\n'+
+            'E.g. for Trace Compass server: -data /home/user/server-workspace -vmargs -Dtraceserver.port=8080',
         }
     },
 };
@@ -23,6 +30,7 @@ export const ServerSchema: PreferenceSchema = {
 interface TracePreferenceContribution {
     [TRACE_PATH]?: string
     [TRACE_PORT]: number
+    [TRACE_ARGS]: string
 }
 
 export const TracePreferences = Symbol('TracePreferences');

--- a/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-config.ts
@@ -8,7 +8,7 @@ export const PortBusy = ApplicationError.declare(-32650, code => ({
 
 export interface StartTraceServerOptions {
     path?: string
-    port?: number
+    args?: string
 }
 
 export const TraceServerConfigService = Symbol('TraceServerConfigService');

--- a/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
+++ b/theia-extensions/viewer-prototype/src/common/trace-server-url-provider.ts
@@ -1,5 +1,5 @@
 export const TRACE_SERVER_DEFAULT_URL = 'http://localhost:{}/tsp/api';
-export const TRACE_SERVER_DEFAULT_PORT = 8080;
+export const TRACE_VIEWER_DEFAULT_PORT = 8080;
 
 export const TraceServerUrlProvider = Symbol('TraceServerUrlProvider');
 export interface TraceServerUrlProvider {


### PR DESCRIPTION
fixes #479 

As discussed, we're changing the settings field to contain just _Trace Server Path_ and _Tracer Server Arguments_ (set by default to '-vmargs -Dtraceserver.port=8080').

Previous implementation was to have a _Trace Server Port_ argument. This PR assumes that valid arguments are provided and makes use of regEx to extract the port from the arguments string. What validation can we put to check if the provided arguments are valid?

![Screen Shot 2021-11-30 at 11 14 06 AM](https://user-images.githubusercontent.com/92893187/144095074-343aead0-fbfb-40cf-ab76-592f80ac4817.png)


