### PR TITLE
Rename opened traces context menu delete command

### DIFF
--- a/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-opened-traces-widget.tsx
@@ -178,7 +178,7 @@ export class ReactOpenTracesWidget extends React.Component<ReactOpenTracesWidget
                     <h4 className='trace-element-name'>{traceName}</h4>
                     {this.renderTracesForExperiment(props.index)}
                 </div>
-                <div className='remove-trace-button-container' title='Remove traces from Trace Viewer'>
+                <div className='remove-trace-button-container' title='Remove trace from Trace Viewer'>
                     <button data-tip data-for="removeTip" className='remove-trace-button'
                         onClick={event => {this.handleOnExperimentDeleted(event,traceUUID);}}
                     >

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-commands.ts
@@ -13,8 +13,8 @@ export namespace TraceExplorerCommands {
         label: 'Close Trace'
     };
 
-    export const DELETE_TRACE: Command = {
-        id: 'trace-explorer:delete-trace',
-        label: 'Delete Trace'
+    export const REMOVE_TRACE: Command = {
+        id: 'trace-explorer:remove-trace',
+        label: 'Remove Trace'
     };
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-contribution.ts
@@ -37,8 +37,8 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
         });
 
         menus.registerMenuAction(TraceExplorerMenus.PREFERENCE_EDITOR_CONTEXT_MENU, {
-            commandId: TraceExplorerCommands.DELETE_TRACE.id,
-            label: TraceExplorerCommands.DELETE_TRACE.label,
+            commandId: TraceExplorerCommands.REMOVE_TRACE.id,
+            label: TraceExplorerCommands.REMOVE_TRACE.label,
             order: 'c'
         });
     }
@@ -59,7 +59,7 @@ export class TraceExplorerContribution extends AbstractViewContribution<TraceExp
             }
         });
 
-        registry.registerCommand(TraceExplorerCommands.DELETE_TRACE, {
+        registry.registerCommand(TraceExplorerCommands.REMOVE_TRACE, {
             execute: (traceUUID: string) => {
                 explorerWidget.deleteExperiment(traceUUID);
             }


### PR DESCRIPTION
fixes #277

'Delete trace' renamed to 'Remove trace' to make it consistent with the remove traces tooltip

![Screen Shot 2021-11-30 at 12 38 34 PM](https://user-images.githubusercontent.com/92893187/144107652-0bb9f946-2ff1-4abe-8d7b-124dc1c738ab.png)

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>