### PR TITLE
Add typescript to devDependencies in main packages.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "devDependencies": {
     "@theia/cli": "1.10.0",
     "jsonc-parser": "^3.0.0",
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "typescript": "latest"
   },
   "workspaces": [
     "examples/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12208,7 +12208,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
+json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:


### PR DESCRIPTION
This fixes the occasional build failure "/bin/sh: 1: tsc: not found"

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>