### PR TITLE
Add intuitive way to open additional traces

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
@@ -3,14 +3,8 @@ import { ReactWidget } from '@theia/core/lib/browser';
 import * as React from 'react';
 import { CommandService } from '@theia/core';
 import { OpenTraceCommand } from '../../trace-viewer/trace-viewer-commands';
-import { PortBusy, TraceServerConfigService } from '../../../common/trace-server-config';
 import { PreferenceService } from '@theia/core/lib/browser';
 import { TRACE_PATH, TRACE_PORT } from '../../trace-server-preference';
-import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
-import { TspClientProvider } from '../../tsp-client-provider-impl';
-import { TspClientResponse } from 'tsp-typescript-client/lib/protocol/tsp-client-response';
-import { HealthStatus } from 'tsp-typescript-client/lib/models/health';
-import { MessageService } from '@theia/core';
 
 @injectable()
 export class TraceExplorerPlaceholderWidget extends ReactWidget {
@@ -18,24 +12,17 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
     static LABEL = 'Trace Exploerer Placeholder Widget';
     protected path: string | undefined;
     protected port: number | undefined;
-    private tspClient: TspClient;
 
     state = {
         loading: false
     };
 
-    private constructor(
-        @inject(TspClientProvider) private tspClientProvider: TspClientProvider
-    ) {
+    private constructor() {
         super();
-        this.tspClient = this.tspClientProvider.getTspClient();
-        this.tspClientProvider.addTspClientChangeListener(tspClient => this.tspClient = tspClient);
     }
 
     @inject(CommandService) protected readonly commandService!: CommandService;
     @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
-    @inject(TraceServerConfigService) protected readonly traceServerConfigService: TraceServerConfigService;
-    @inject(MessageService) protected readonly messageService: MessageService;
 
     @postConstruct()
     init(): void {
@@ -79,44 +66,10 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
     protected handleOpenTrace = async (): Promise<void> => this.doHandleOpenTrace();
 
     private async doHandleOpenTrace() {
-        try {
-            this.state.loading = true;
-            this.update();
-            const healthResponse = await this.tspClient.checkHealth();
-            if ((healthResponse as TspClientResponse<HealthStatus>).getModel()?.status === 'UP') {
-                this.state.loading = false;
-                this.update();
-                this.commandService.executeCommand(OpenTraceCommand.id);
-            }
-        }
-        catch (e) {
-            this.messageService.showProgress({
-                text: ''
-            }).then(async progress => {
-                progress.report({ message: 'Launching trace server... ', work: { done: 10, total: 100 } });
-                try {
-                    const resolve = await this.traceServerConfigService.startTraceServer(this.path, this.port);
-                    if (resolve === 'success') {
-                        progress.report({ message: `Trace server started on port: ${this.port}.`, work: { done: 100, total: 100 } });
-                        progress.cancel();
-                        this.commandService.executeCommand(OpenTraceCommand.id);
-                    }
-                }
-                catch (err) {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    if (PortBusy.is(err as any)) {
-                        this.messageService.error(
-                            `Error opening serial port ${this.port}. (Port busy)`);
-                    } else {
-                        this.messageService.error(
-                            'Failed to start the trace server: no such file or directory. Please make sure that the path is correct in Trace Viewer settings and retry');
-                    }
-                    progress.cancel();
-                }
-                this.state.loading = false;
-                this.update();
-            });
-        }
+        this.state.loading = true;
+        this.update();
+        await this.commandService.executeCommand(OpenTraceCommand.id);
+        this.state.loading = false;
+        this.update();
     }
-
 }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
@@ -31,6 +31,11 @@ export namespace TraceViewerToolbarCommands {
         label: 'Markers',
         iconClass: 'fa fa-bars fa-lg',
     };
+    export const OPEN_TRACE: Command = {
+        id: 'trace.viewer.openTrace',
+        label: 'Open Trace',
+        iconClass: 'fa fa-folder-open-o fa-lg',
+    };
 }
 
 export namespace TraceViewerToolbarMenus {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -8,6 +8,8 @@ import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-mana
 import { TraceViewerWidget } from './trace-viewer';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
+import { TraceExplorerOpenedTracesWidget } from '../trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget';
+import { OpenTraceCommand } from './trace-viewer-commands';
 
 @injectable()
 export class TraceViewerToolbarContribution implements TabBarToolbarContribution, CommandContribution {
@@ -80,6 +82,18 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             },
             execute: () => {
                 signalManager().fireResetZoomSignal();
+            }
+        });
+        registry.registerCommand(
+            TraceViewerToolbarCommands.OPEN_TRACE, {
+            isVisible: (w: Widget) => {
+                if (w instanceof TraceExplorerOpenedTracesWidget) {
+                    return true;
+                }
+                return false;
+            },
+            execute: async () => {
+                await registry.executeCommand(OpenTraceCommand.id);
             }
         });
     }
@@ -201,6 +215,12 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             priority: 5,
             group: 'navigation',
             onDidChange: this.onMakerSetsChangedEvent,
+        });
+        registry.registerItem({
+            id: TraceViewerToolbarCommands.OPEN_TRACE.id,
+            command: TraceViewerToolbarCommands.OPEN_TRACE.id,
+            tooltip: TraceViewerToolbarCommands.OPEN_TRACE.label,
+            priority: 6,
         });
     }
 }


### PR DESCRIPTION
fixes #193 

- Button added to the 'Opened Traces' widget header to allow opening additional traces. Button appears when mouse is hovered over widget
- In my approach I'm emitting a new signal when button is clicked, but I can reuse one of the existing signals instead

Named button tooltip "Open New Trace" because I think it differentiates from the context menu "Open Trace" command:
<img width="272" alt="Screen Shot 2021-12-03 at 2 46 48 PM" src="https://user-images.githubusercontent.com/92893187/144670865-e5731fab-c682-4df6-af2a-559eed3d9ea1.png">

<img width="301" alt="Screen Shot 2021-12-03 at 2 49 16 PM" src="https://user-images.githubusercontent.com/92893187/144670926-41a94412-7433-4811-a4d6-04146ea93f22.png">

Unable to add '+' to the icon because theia commands accept a single iconClass param and I couldn't find a way to stack multiple icons in one element. We can upgrade font-awesome to v5 to get access to a folder-plus icon