### PR TITLE
Fix filter tree alignment

### DIFF
--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -58,12 +58,14 @@ exports[`Entry with children All unchecked 1`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "0px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 12,
               }
             }
           >
@@ -84,12 +86,13 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -110,7 +113,7 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
+          </div>
           parent
         </td>
         <td>
@@ -119,19 +122,21 @@ exports[`Entry with children All unchecked 1`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "15px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 24,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -152,41 +157,23 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child1
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child1 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "15px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 24,
               }
             }
           >
@@ -207,12 +194,13 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -233,48 +221,30 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child2 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "30px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 36,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -295,48 +265,30 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           grandchild1
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           grandchild1 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "30px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 36,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -357,30 +309,10 @@ exports[`Entry with children All unchecked 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           grandchild2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           grandchild2 second column
         </td>
       </tr>
@@ -441,12 +373,14 @@ exports[`Entry with children Check one grandchild 1`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "0px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 12,
               }
             }
           >
@@ -467,12 +401,13 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -493,7 +428,7 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
+          </div>
           parent
         </td>
         <td>
@@ -502,19 +437,21 @@ exports[`Entry with children Check one grandchild 1`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "15px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 24,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -535,41 +472,23 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child1
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child1 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "15px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 24,
               }
             }
           >
@@ -590,12 +509,13 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -616,48 +536,30 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child2 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "30px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 36,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -678,48 +580,30 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           grandchild1
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           grandchild1 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "30px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 36,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -740,30 +624,10 @@ exports[`Entry with children Check one grandchild 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           grandchild2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           grandchild2 second column
         </td>
       </tr>
@@ -824,12 +688,14 @@ exports[`Entry with children Collapse one child 1`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "0px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 12,
               }
             }
           >
@@ -850,12 +716,13 @@ exports[`Entry with children Collapse one child 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -876,7 +743,7 @@ exports[`Entry with children Collapse one child 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
+          </div>
           parent
         </td>
         <td>
@@ -885,19 +752,21 @@ exports[`Entry with children Collapse one child 1`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "15px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 24,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -918,41 +787,23 @@ exports[`Entry with children Collapse one child 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child1
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child1 second column
         </td>
       </tr>
       <tr>
         <td>
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "marginLeft": "15px",
+                "display": "inline-block",
                 "paddingRight": 5,
+                "textAlign": "right",
+                "width": 24,
               }
             }
           >
@@ -973,12 +824,13 @@ exports[`Entry with children Collapse one child 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
+          </div>
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -999,30 +851,10 @@ exports[`Entry with children Collapse one child 1`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           child2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           child2 second column
         </td>
       </tr>
@@ -1093,12 +925,14 @@ Array [
       <tbody>
         <tr>
           <td>
-            <span
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "marginLeft": "0px",
+                  "display": "inline-block",
                   "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 12,
                 }
               }
             >
@@ -1119,12 +953,13 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
+            </div>
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "padding": 5,
+                  "display": "inline",
+                  "paddingRight": 5,
                 }
               }
             >
@@ -1145,7 +980,7 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
+            </div>
             parent
           </td>
           <td>
@@ -1154,19 +989,21 @@ Array [
         </tr>
         <tr>
           <td>
-            <span
+            <div
               style={
                 Object {
-                  "marginLeft": "15px",
-                  "paddingLeft": 20,
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 24,
                 }
               }
             />
-            <span
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "padding": 5,
+                  "display": "inline",
+                  "paddingRight": 5,
                 }
               }
             >
@@ -1187,41 +1024,23 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
+            </div>
             child1
           </td>
           <td>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
             child1 second column
           </td>
         </tr>
         <tr>
           <td>
-            <span
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "marginLeft": "15px",
+                  "display": "inline-block",
                   "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 24,
                 }
               }
             >
@@ -1242,12 +1061,13 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
+            </div>
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "padding": 5,
+                  "display": "inline",
+                  "paddingRight": 5,
                 }
               }
             >
@@ -1268,48 +1088,30 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
+            </div>
             child2
           </td>
           <td>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
             child2 second column
           </td>
         </tr>
         <tr>
           <td>
-            <span
+            <div
               style={
                 Object {
-                  "marginLeft": "30px",
-                  "paddingLeft": 20,
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 36,
                 }
               }
             />
-            <span
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "padding": 5,
+                  "display": "inline",
+                  "paddingRight": 5,
                 }
               }
             >
@@ -1330,48 +1132,30 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
+            </div>
             grandchild1
           </td>
           <td>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
             grandchild1 second column
           </td>
         </tr>
         <tr>
           <td>
-            <span
+            <div
               style={
                 Object {
-                  "marginLeft": "30px",
-                  "paddingLeft": 20,
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 36,
                 }
               }
             />
-            <span
+            <div
               onClick={[Function]}
               style={
                 Object {
-                  "padding": 5,
+                  "display": "inline",
+                  "paddingRight": 5,
                 }
               }
             >
@@ -1392,30 +1176,10 @@ Array [
                   style={Object {}}
                 />
               </svg>
-            </span>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
+            </div>
             grandchild2
           </td>
           <td>
-            <span
-              onClick={[Function]}
-              style={
-                Object {
-                  "padding": 5,
-                }
-              }
-            >
-              
-            </span>
             grandchild2 second column
           </td>
         </tr>
@@ -1477,18 +1241,12 @@ exports[`one level of entries 1`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
-              }
-            }
-          />
-          <span
-            style={
-              Object {
-                "marginLeft": 5,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
@@ -1500,44 +1258,18 @@ exports[`one level of entries 1`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
-          <span
-            style={
-              Object {
-                "marginLeft": 5,
-              }
-            }
-          />
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           entry2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           entry2 column2
         </td>
       </tr>
@@ -1598,19 +1330,21 @@ exports[`one level of entries 2`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -1631,7 +1365,7 @@ exports[`one level of entries 2`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
+          </div>
           entry1
         </td>
         <td>
@@ -1640,19 +1374,21 @@ exports[`one level of entries 2`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -1673,30 +1409,10 @@ exports[`one level of entries 2`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           entry2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           entry2 column2
         </td>
       </tr>
@@ -1718,19 +1434,21 @@ exports[`one level of entries 3`] = `
     <tbody>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -1751,7 +1469,7 @@ exports[`one level of entries 3`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
+          </div>
           entry1
         </td>
         <td>
@@ -1760,19 +1478,21 @@ exports[`one level of entries 3`] = `
       </tr>
       <tr>
         <td>
-          <span
+          <div
             style={
               Object {
-                "marginLeft": "0px",
-                "paddingLeft": 20,
+                "display": "inline-block",
+                "paddingRight": 5,
+                "width": 12,
               }
             }
           />
-          <span
+          <div
             onClick={[Function]}
             style={
               Object {
-                "padding": 5,
+                "display": "inline",
+                "paddingRight": 5,
               }
             }
           >
@@ -1793,30 +1513,10 @@ exports[`one level of entries 3`] = `
                 style={Object {}}
               />
             </svg>
-          </span>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
+          </div>
           entry2
         </td>
         <td>
-          <span
-            onClick={[Function]}
-            style={
-              Object {
-                "padding": 5,
-              }
-            }
-          >
-            
-          </span>
           entry2 column2
         </td>
       </tr>

--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/table-row.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/table-row.test.tsx.snap
@@ -3,19 +3,21 @@
 exports[`Checked status 1`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "0px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 12,
         }
       }
     />
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -36,17 +38,7 @@ exports[`Checked status 1`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     cell1 - text
   </td>
 </tr>
@@ -55,19 +47,21 @@ exports[`Checked status 1`] = `
 exports[`Checked status 2`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "0px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 12,
         }
       }
     />
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -88,17 +82,7 @@ exports[`Checked status 2`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     cell1 - text
   </td>
 </tr>
@@ -107,19 +91,21 @@ exports[`Checked status 2`] = `
 exports[`Checked status 3`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "0px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 12,
         }
       }
     />
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -140,17 +126,7 @@ exports[`Checked status 3`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     cell1 - text
   </td>
 </tr>
@@ -159,19 +135,21 @@ exports[`Checked status 3`] = `
 exports[`Levels 1`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "15px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 24,
         }
       }
     />
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -192,17 +170,7 @@ exports[`Levels 1`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     cell1 - text
   </td>
 </tr>
@@ -211,19 +179,21 @@ exports[`Levels 1`] = `
 exports[`Levels 2`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "150px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 132,
         }
       }
     />
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -244,17 +214,7 @@ exports[`Levels 2`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     cell1 - text
   </td>
 </tr>
@@ -264,12 +224,14 @@ exports[`Multiple labels With children and labels 1`] = `
 Array [
   <tr>
     <td>
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "marginLeft": "0px",
+            "display": "inline-block",
             "paddingRight": 5,
+            "textAlign": "right",
+            "width": 12,
           }
         }
       >
@@ -290,12 +252,13 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
+      </div>
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -316,48 +279,30 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       parent 1 text
     </td>
     <td>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
       parent 2 text
     </td>
   </tr>,
   <tr>
     <td>
-      <span
+      <div
         style={
           Object {
-            "marginLeft": "15px",
-            "paddingLeft": 20,
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 24,
           }
         }
       />
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -378,48 +323,30 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       child1
     </td>
     <td>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
       child 1 text
     </td>
   </tr>,
   <tr>
     <td>
-      <span
+      <div
         style={
           Object {
-            "marginLeft": "15px",
-            "paddingLeft": 20,
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 24,
           }
         }
       />
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -440,30 +367,10 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       child2
     </td>
     <td>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
       child 2 text
     </td>
   </tr>,
@@ -473,31 +380,15 @@ Array [
 exports[`Uncheckable 1`] = `
 <tr>
   <td>
-    <span
+    <div
       style={
         Object {
-          "marginLeft": "0px",
-          "paddingLeft": 20,
+          "display": "inline-block",
+          "paddingRight": 5,
+          "width": 12,
         }
       }
     />
-    <span
-      style={
-        Object {
-          "marginLeft": 5,
-        }
-      }
-    />
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
     cell1 - text
   </td>
 </tr>
@@ -507,12 +398,14 @@ exports[`with children With children 1`] = `
 Array [
   <tr>
     <td>
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "marginLeft": "0px",
+            "display": "inline-block",
             "paddingRight": 5,
+            "textAlign": "right",
+            "width": 12,
           }
         }
       >
@@ -533,12 +426,13 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
+      </div>
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -559,35 +453,27 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       parent text
     </td>
   </tr>,
   <tr>
     <td>
-      <span
+      <div
         style={
           Object {
-            "marginLeft": "15px",
-            "paddingLeft": 20,
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 24,
           }
         }
       />
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -608,35 +494,27 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       child 1 text
     </td>
   </tr>,
   <tr>
     <td>
-      <span
+      <div
         style={
           Object {
-            "marginLeft": "15px",
-            "paddingLeft": 20,
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 24,
           }
         }
       />
-      <span
+      <div
         onClick={[Function]}
         style={
           Object {
-            "padding": 5,
+            "display": "inline",
+            "paddingRight": 5,
           }
         }
       >
@@ -657,17 +535,7 @@ Array [
             style={Object {}}
           />
         </svg>
-      </span>
-      <span
-        onClick={[Function]}
-        style={
-          Object {
-            "padding": 5,
-          }
-        }
-      >
-        
-      </span>
+      </div>
       child 2 text
     </td>
   </tr>,
@@ -677,12 +545,14 @@ Array [
 exports[`with children With children collapsed 1`] = `
 <tr>
   <td>
-    <span
+    <div
       onClick={[Function]}
       style={
         Object {
-          "marginLeft": "0px",
+          "display": "inline-block",
           "paddingRight": 5,
+          "textAlign": "right",
+          "width": 12,
         }
       }
     >
@@ -703,12 +573,13 @@ exports[`with children With children collapsed 1`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
+    </div>
+    <div
       onClick={[Function]}
       style={
         Object {
-          "padding": 5,
+          "display": "inline",
+          "paddingRight": 5,
         }
       }
     >
@@ -729,17 +600,7 @@ exports[`with children With children collapsed 1`] = `
           style={Object {}}
         />
       </svg>
-    </span>
-    <span
-      onClick={[Function]}
-      style={
-        Object {
-          "padding": 5,
-        }
-      }
-    >
-      
-    </span>
+    </div>
     parent text
   </td>
 </tr>

--- a/packages/react-components/src/components/utils/filtrer-tree/checkbox-component.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/checkbox-component.tsx
@@ -30,8 +30,8 @@ export class CheckboxComponent extends React.Component<CheckboxProps> {
     };
 
     render(): JSX.Element {
-        return <span style={{padding: 5}} onClick={this.handleClick}>
+        return <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClick}>
                 {this.renderCheckbox(this.props.checkedStatus)}
-            </span>;
+            </div>;
     }
 }

--- a/packages/react-components/src/components/utils/filtrer-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/table-row.tsx
@@ -32,13 +32,12 @@ export class TableRow extends React.Component<TableRowProps> {
     };
 
     renderToggleCollapse = (): React.ReactNode => {
-        const marginLeft = this.props.level * 15 + 'px';
+        const width = (this.props.level + 1) * 12;
         return (
             (this.props.node.children.length === 0)
-                ? <span style={{ marginLeft: marginLeft, paddingLeft: 20 }}></span>
-                : <span style={{ marginLeft: marginLeft, paddingRight: 5 }} onClick={this.handleCollapse}>
-                    {(this.isCollapsed() ? icons.expand : icons.collapse)}
-                </span>
+                ? <div style={{ width, paddingRight: 5, display: 'inline-block' }} />
+                : <div style={{ width, paddingRight: 5, textAlign: 'right', display: 'inline-block' }} onClick={this.handleCollapse}>
+                    {(this.isCollapsed() ? icons.expand : icons.collapse)}</div>
         );
     };
 
@@ -51,25 +50,21 @@ export class TableRow extends React.Component<TableRowProps> {
                 checkedStatus={checkedStatus}
                 onToggleCheck={this.props.onToggleCheck}
             />
-            : <span style={{ marginLeft: 5 }}></span>;
+            : undefined;
     };
 
-    renderClose = (): React.ReactNode => <span style={{ padding: 5 }} onClick={this.handleClose}>{this.props.isClosable ? icons.close : ''}</span>;
+    renderCloseButton = (): React.ReactNode =>
+        (this.props.isClosable && this.props.node.id)
+            ? <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClose}>{icons.close}</div>
+            : undefined;
 
-    renderRow = (): React.ReactNode => this.props.node.labels.map((_label: string, index) => {
-        let toggleCollapse: React.ReactNode;
-        let toggleCheck: React.ReactNode;
-        if (index === 0) {
-            toggleCollapse = this.renderToggleCollapse();
-            toggleCheck = this.renderCheckbox();
-        }
-
-        return <TableCell key={this.props.node.id + '-' + index} index={index} node={this.props.node}>
-            {toggleCollapse}
-            {toggleCheck}
-            {this.props.node.id ? this.renderClose() : <></>}
-        </TableCell>;
-    });
+    renderRow = (): React.ReactNode => this.props.node.labels.map((_label: string, index) =>
+        <TableCell key={this.props.node.id + '-' + index} index={index} node={this.props.node}>
+            { (index === 0) ? this.renderToggleCollapse() : undefined }
+            { (index === 0) ? this.renderCheckbox() : undefined }
+            { (index === 0) ? this.renderCloseButton() : undefined }
+        </TableCell>
+    );
 
     renderChildren = (): React.ReactNode | undefined => {
         if (this.props.node.children.length && !this.isCollapsed()) {


### PR DESCRIPTION
Replace spans with divs in first column of filter tree. Use flexbox to
create fixed width indentation box containing an optional right-aligned
expand/collapse button. Remove unnecessary padding in all buttons.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>