### PR TITLE
add unit tests for the events table

### DIFF
--- a/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
+++ b/packages/react-components/src/components/__tests__/__snapshots__/table-renderer-components.test.tsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table output component tests Cell renderer 1`] = `"test cell"`;
+
+exports[`Table output component tests Cell renderer with search selection 1`] = `
+Array [
+  <span>
+    
+    <span
+      style={
+        Object {
+          "backgroundColor": "#FFFF00",
+        }
+      }
+    >
+      test
+    </span>
+  </span>,
+  <span>
+     cell
+  </span>,
+]
+`;
+
+exports[`Table output component tests Empty search filter renderer 1`] = `
+<div
+  data-testid="search-filter-element-parent"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <svg
+    aria-hidden="true"
+    className="svg-inline--fa fa-search fa-w-16 "
+    data-icon="search"
+    data-prefix="fas"
+    focusable="false"
+    role="img"
+    style={
+      Object {
+        "marginLeft": "10px",
+      }
+    }
+    viewBox="0 0 512 512"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+      fill="currentColor"
+      style={Object {}}
+    />
+  </svg>
+</div>
+`;
+
+exports[`Table output component tests Loading renderer in loading 1`] = `
+<svg
+  aria-hidden="true"
+  className="svg-inline--fa fa-spinner fa-w-16 "
+  data-icon="spinner"
+  data-prefix="fas"
+  focusable="false"
+  role="img"
+  style={Object {}}
+  viewBox="0 0 512 512"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+    fill="currentColor"
+    style={Object {}}
+  />
+</svg>
+`;
+
+exports[`Table output component tests Loading renderer not loading 1`] = `"test cell"`;

--- a/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
+++ b/packages/react-components/src/components/__tests__/table-renderer-components.test.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react';
+import { cleanup, render, fireEvent, screen } from '@testing-library/react';
+import { create } from 'react-test-renderer';
+import { mount } from 'enzyme';
+import { TableOutputComponent } from '../table-output-component';
+import { CellRenderer, LoadingRenderer, SearchFilterRenderer } from '../table-renderer-components';
+import { AbstractOutputProps } from '../abstract-output-component';
+import { TimeGraphUnitController } from 'timeline-chart/lib/time-graph-unit-controller';
+import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
+import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { AgGridReact } from 'ag-grid-react';
+import { ColDef, Column, ColumnApi, GridApi, IRowModel, RowNode } from 'ag-grid-community';
+
+afterEach(() => {
+    cleanup
+    jest.clearAllMocks();
+});
+
+describe('Table output component tests', () => {
+    
+    test('Renders AG-Grid table with provided props & state', async () => {
+        const tableOutputComponentProps: AbstractOutputProps = {
+            tooltipComponent: null,
+            style: {
+                width: 0,
+                height: 0,
+                rowHeight: 0,
+                naviBackgroundColor: 0,
+                chartBackgroundColor: 0,
+                cursorColor: 0,
+                lineColor: 0,
+                componentLeft: 0,
+                chartOffset: 0
+            },
+            tspClient: new TspClient('testURL'),
+            traceId: '0',
+            outputDescriptor: {
+                id: '0',
+                name: '',
+                description: '',
+                type: '',
+                queryParameters: new Map<string, any>(),
+                start: BigInt(0),
+                end: BigInt(0),
+                final: true,
+                compatibleProviders: []            
+            },
+            markerCategories: undefined,
+            markerSetId: '0',
+            range: new TimeRange(BigInt(0), BigInt(0)),
+            nbEvents: 0,
+            viewRange: new TimeRange(BigInt(0), BigInt(0)),
+            selectionRange: undefined,
+            onOutputRemove: () => 0,
+            unitController: new TimeGraphUnitController(BigInt(0), { start: BigInt(0), end: BigInt(0)}),
+            backgroundTheme: 'light',
+            tooltipXYComponent: null,
+            outputWidth: 0
+        };
+        
+        const tableOutputComponentState = [
+            {
+                "headerName":"Trace",
+                "field":"0",
+                "width":0,
+                "resizable":true,
+                "cellRenderer":"cellRenderer",
+                "cellRendererParams":{"filterModel":{},"searchResultsColor":"#cccc00"},
+                "suppressMenu":true,
+                "filter":"agTextColumnFilter",
+                "floatingFilter":true,
+                "floatingFilterComponent":"searchFilterRenderer",
+                "floatingFilterComponentParams":{"suppressFilterButton":true,"colName":"0"},
+                "icons":{"filter":""},
+                "tooltipField":"0"
+            }
+        ];
+
+        const wrapper = mount(<TableOutputComponent {...tableOutputComponentProps} />);
+
+        wrapper.setState(
+            {tableColumns: tableOutputComponentState}
+        );
+
+        expect(wrapper.contains(<TableOutputComponent {...tableOutputComponentProps} />)).toBe(true);
+        expect(wrapper.state('tableColumns')).toEqual(tableOutputComponentState);
+        // Renders with provided props
+        expect(wrapper.props().backgroundTheme).toEqual('light');
+        expect(wrapper.props().tooltipComponent).toEqual(null);
+        expect(wrapper.props().style).toEqual({
+            width: 0,
+            height: 0,
+            rowHeight: 0,
+            naviBackgroundColor: 0,
+            chartBackgroundColor: 0,
+            cursorColor: 0,
+            lineColor: 0,
+            componentLeft: 0,
+            chartOffset: 0
+        });
+
+        // Instance of AgGrid is present when you render TableOutputComponent
+        expect(wrapper.find(AgGridReact).length).toEqual(1);
+    });
+
+    const mockOnFilterChange = jest.fn();
+    const mockOnClickNext = jest.fn();
+    const mockOnClickPrevious = jest.fn();
+    const mockParentilterInstance = jest.fn();
+    const mockCurrentParentModel = jest.fn();
+    const mockFilterChangedCallback = jest.fn();
+    const mockFilterModifiedCallback = jest.fn();
+    const mockValueGetter = jest.fn();
+    const mockDoesRowPassOtherFilter = jest.fn();
+
+    test('Empty search filter renderer', () => {
+        const searchFilter = create(<SearchFilterRenderer 
+            colName={'jest Test'}
+            onFilterChange={mockOnFilterChange}
+            onclickNext={mockOnClickNext}
+            onclickPrevious={mockOnClickPrevious} 
+            column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)} 
+            filterParams={
+                {
+                    api: new GridApi(),
+                    column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
+                    colDef: {} as ColDef,
+                    rowModel: '' as unknown as IRowModel,
+                    filterChangedCallback: mockFilterChangedCallback,
+                    filterModifiedCallback: mockFilterModifiedCallback,
+                    valueGetter: mockValueGetter,
+                    doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
+                    context: '',
+                }
+            } 
+            currentParentModel={mockCurrentParentModel} 
+            parentFilterInstance={mockParentilterInstance} 
+            suppressFilterButton={false} 
+            api={new GridApi()} 
+            onFloatingFilterChanged={(change: any) => false}
+        />).toJSON();
+        expect(searchFilter).toMatchSnapshot();
+    });
+
+    test('Search filter renderer key interactions', () => {
+        render(<SearchFilterRenderer 
+            colName={'jest Test'}
+            onFilterChange={mockOnFilterChange}
+            onclickNext={mockOnClickNext}
+            onclickPrevious={mockOnClickPrevious} 
+            column={new Column({} as ColDef, {} as ColDef, 'jest Test', true)} 
+            filterParams={
+                {
+                    api: new GridApi(),
+                    column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
+                    colDef: {} as ColDef,
+                    rowModel: '' as unknown as IRowModel,
+                    filterChangedCallback: mockFilterChangedCallback,
+                    filterModifiedCallback: mockFilterModifiedCallback,
+                    valueGetter: mockValueGetter,
+                    doesRowPassOtherFilter: mockDoesRowPassOtherFilter,
+                    context: '',
+                }
+            } 
+            currentParentModel={mockCurrentParentModel} 
+            parentFilterInstance={mockParentilterInstance} 
+            suppressFilterButton={false} 
+            api={new GridApi()} 
+            onFloatingFilterChanged={(change: any) => false}
+        />);
+
+        const parentDiv = screen.getByTestId('search-filter-element-parent');
+        fireEvent.click(parentDiv);
+        const input = screen.getByTestId('search-filter-element-input');
+        fireEvent.keyDown(input, {key: 'Enter', code: 'Enter', charCode: 13});
+        expect(mockOnClickNext).toHaveBeenCalledTimes(1);
+        fireEvent.keyDown(input, {key: 'Escape', code: 'Escape', charCode: 27});
+        expect(mockOnFilterChange).toHaveBeenCalledTimes(1);
+    });
+
+    const cellRendererProps: any = {
+        value: 'test cell',
+        valueFormatted: 'test cell',
+        getValue: function () {
+            return 'test cell';
+        },
+        setValue: function (val: any): void {
+            const value = val;
+        },
+        formatValue: function (value: any) {
+            return value;
+        },
+        data: {},
+        node: {} as RowNode,
+        colDef: {} as ColDef,
+        column: new Column({} as ColDef, {} as ColDef, 'jest Test', true),
+        rowIndex: 0,
+        api: new GridApi(),
+        columnApi: new ColumnApi(),
+        context: '',
+        refreshCell: () => {},
+        $scope: '',
+        eGridCell: document.createElement('div'),
+        eParentOfValue: document.createElement('div'),
+        addRenderedRowListener: function (eventType: string, listener: Function): void {
+            throw new Error('Function not implemented.');
+        },
+        searchResultsColor: '#FFFF00',
+        filterModel: new Map<string,string>()
+    }
+
+    test('Cell renderer', () => {
+        const cellRenderer = create(<CellRenderer {...cellRendererProps}/>).toJSON();
+        expect(cellRenderer).toMatchSnapshot();
+    });
+
+    test('Cell renderer with search selection', () => {
+        cellRendererProps.colDef.field = 'testField';
+        cellRendererProps.filterModel.set('testField', 'test');
+        cellRendererProps.data = {'isMatched' : true};
+
+        const cellRenderer = create(<CellRenderer {...cellRendererProps}/>).toJSON();
+        expect(cellRenderer).toMatchSnapshot();
+    });
+
+    test('Loading renderer not loading', () => {
+        delete cellRendererProps.filterModel;
+        delete cellRendererProps.searchResultsColor;
+
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps}/>).toJSON();
+        expect(loadingRenderer).toMatchSnapshot();
+    });
+
+    test('Loading renderer in loading', () => {
+        cellRendererProps.value = undefined;
+
+        const loadingRenderer = create(<LoadingRenderer {...cellRendererProps}/>).toJSON();
+        expect(loadingRenderer).toMatchSnapshot();
+    });
+
+})

--- a/packages/react-components/src/components/table-renderer-components.tsx
+++ b/packages/react-components/src/components/table-renderer-components.tsx
@@ -99,7 +99,7 @@ export class SearchFilterRenderer extends React.Component<SearchFilterRendererPr
 
     render(): JSX.Element {
         return (
-            <div onMouseEnter={this.onMouseEnterHandler} onMouseLeave={this.onMouseLeaveHandler} onClick={this.onClickHandler}>
+            <div data-testid="search-filter-element-parent" onMouseEnter={this.onMouseEnterHandler} onMouseLeave={this.onMouseLeaveHandler} onClick={this.onClickHandler}>
                 {!this.state.hasClicked && !this.state.hasHovered &&
                     <FontAwesomeIcon style={{ marginLeft: '10px' }} icon={faSearch} />}
                 {!this.state.hasClicked && this.state.hasHovered &&
@@ -109,7 +109,13 @@ export class SearchFilterRenderer extends React.Component<SearchFilterRendererPr
                     </div>}
                 {this.state.hasClicked &&
                     <div>
-                        <input type="text" autoFocus={true} onKeyDown={this.onKeyDownEvent} onInput={this.onInputBoxChanged} style={{ width: '50%', margin: '10px' }} />
+                        <input
+                            data-testid="search-filter-element-input"
+                            type="text" autoFocus={true}
+                            onKeyDown={this.onKeyDownEvent}
+                            onInput={this.onInputBoxChanged}
+                            style={{ width: '50%', margin: '10px' }}
+                        />
                         <FontAwesomeIcon className='hoverClass' icon={faTimes} style={{ marginTop: '20px' }} onClick={this.onCloseClickHandler} />
                         <FontAwesomeIcon className='hoverClass' icon={faAngleDown} style={{ marginLeft: '10px', marginTop: '20px' }} onClick={this.onDownClickHandler} />
                         <FontAwesomeIcon className='hoverClass' icon={faAngleUp} style={{ marginLeft: '10px', marginTop: '20px' }} onClick={this.onUpClickHandler} />


### PR DESCRIPTION
Created some unit tests for user-defined functions and components used in the events table. Was unable to create comprehensive tests for TableOutputComponent since its entirely built upon the AG-Grid library, and snapshot testing does not show the rendered HTML of AG-Grid. Another way to test TableOutputComponent could be to stub api calls made by the component to fetch table data and check if the internal state of the component (table columns & lines) updates. I was unable to mock tsp-client api calls or stub responses since jest could not reference the requests being made by the component's methods. But I believe we can later add to this test once we figure out a way to do so. Also included snapshot and unit tests for TableRendererComponents which are used by TableOutputComponent

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>