### PR TITLE
Clarify in the UI that open traces searches recursively

### DIFF
--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-placeholder-widget.tsx
@@ -59,7 +59,8 @@ export class TraceExplorerPlaceholderWidget extends ReactWidget {
     render(): React.ReactNode {
         const { loading } = this.state;
         return <div className='theia-navigator-container' tabIndex={0}>
-            <div className='center'>{'You have not yet opened a trace.'}</div>
+            <div className='center'>{'You have not yet opened a trace.'}</div><br />
+            <div className='center'>{'Select the root directory to begin recursive search for trace files.'}</div>
             <div className='open-workspace-button-container'>
                 <button className='theia-button open-workspace-button' title='Select a trace to open'
                     onClick={this.handleOpenTrace} disabled={loading}>


### PR DESCRIPTION
Users who are new to the tool, or are unfamiliar with CTF, having trouble navigating to the exact location of traces on the disk
- Added a label above the Open Trace button saying: "Select the root directory to begin recursive search for trace files."
- Label is open to suggestions

![Screen Shot 2021-12-08 at 11 02 30 AM](https://user-images.githubusercontent.com/92893187/145251194-c6318779-1b5b-46c5-8658-5b5390d82def.png)

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>