### PR TITLE
Make table-tree columns resizable

### DIFF
--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -50,7 +50,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                 const columns = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({title: header.name, sortable: true, tooltip: header.tooltip});
+                        columns.push({title: header.name, sortable: true, resizable: true, tooltip: header.tooltip});
                     });
                 } else {
                     columns.push({title: 'Name', sortable: true});

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -178,7 +178,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 const columns = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({ title: header.name, sortable: true, tooltip: header.tooltip });
+                        columns.push({ title: header.name, sortable: true, resizable: true, tooltip: header.tooltip });
                     });
                 } else {
                     columns.push({ title: 'Name', sortable: true });
@@ -301,7 +301,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     showCheckboxes={false}
                     onToggleCollapse={this.onToggleCollapse}
                     showHeader={false}
-                    className="timegraph-tree"
+                    className="table-tree timegraph-tree"
                 />
             </div>
             <div ref={this.markerTreeRef} className='scrollable'
@@ -315,7 +315,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                     onToggleCollapse={this.onToggleAnnotationCollapse}
                     onClose={this.onMarkerCategoryRowClose}
                     showHeader={false}
-                    className="timegraph-tree"
+                    className="table-tree timegraph-tree"
                 />
             </div>
         </>;

--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Entry with children All unchecked 1`] = `
     className="table-tree"
     style={
       Object {
-        "borderCollapse": "collapse",
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
       }
     }
   >
@@ -21,880 +21,10 @@ exports[`Entry with children All unchecked 1`] = `
         <th
           onClick={[Function]}
         >
-          Sortable column
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sort fa-w-10 "
-              data-icon="sort"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          onClick={[Function]}
-        >
-          Unsortable column
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 12,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          parent
-        </td>
-        <td>
-          parent second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 24,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child1
-        </td>
-        <td>
-          child1 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 24,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child2
-        </td>
-        <td>
-          child2 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 36,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          grandchild1
-        </td>
-        <td>
-          grandchild1 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 36,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          grandchild2
-        </td>
-        <td>
-          grandchild2 second column
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Entry with children Check one grandchild 1`] = `
-<div>
-  <table
-    className="table-tree"
-    style={
-      Object {
-        "borderCollapse": "collapse",
-      }
-    }
-  >
-    <thead>
-      <tr>
-        <th
-          onClick={[Function]}
-        >
-          Sortable column
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sort fa-w-10 "
-              data-icon="sort"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          onClick={[Function]}
-        >
-          Unsortable column
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 12,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus-square fa-w-14 "
-              data-icon="minus-square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          parent
-        </td>
-        <td>
-          parent second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 24,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child1
-        </td>
-        <td>
-          child1 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 24,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-minus-square fa-w-14 "
-              data-icon="minus-square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child2
-        </td>
-        <td>
-          child2 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 36,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-check-square fa-w-14 "
-              data-icon="check-square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          grandchild1
-        </td>
-        <td>
-          grandchild1 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 36,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          grandchild2
-        </td>
-        <td>
-          grandchild2 second column
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Entry with children Collapse one child 1`] = `
-<div>
-  <table
-    className="table-tree"
-    style={
-      Object {
-        "borderCollapse": "collapse",
-      }
-    }
-  >
-    <thead>
-      <tr>
-        <th
-          onClick={[Function]}
-        >
-          Sortable column
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sort fa-w-10 "
-              data-icon="sort"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          onClick={[Function]}
-        >
-          Unsortable column
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 12,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-down fa-w-14 "
-              data-icon="chevron-down"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          parent
-        </td>
-        <td>
-          parent second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 24,
-              }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child1
-        </td>
-        <td>
-          child1 second column
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "textAlign": "right",
-                "width": 24,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-chevron-right fa-w-10 "
-              data-icon="chevron-right"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
-                style={Object {}}
-              />
-            </svg>
-          </div>
-          child2
-        </td>
-        <td>
-          child2 second column
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
-exports[`Entry with children With filter element 1`] = `
-Array [
-  <div
-    onChange={[Function]}
-  >
-    <input
-      id="input-filter-tree"
-      placeholder="Filter"
-      type="text"
-    />
-  </div>,
-  <div>
-    <table
-      className="table-tree"
-      style={
-        Object {
-          "borderCollapse": "collapse",
-        }
-      }
-    >
-      <thead>
-        <tr>
-          <th
-            onClick={[Function]}
-          >
-            Sortable column
+          <span>
+            Sortable column     
             <span
-              style={
-                Object {
-                  "float": "right",
-                }
-              }
+              className="sort-icon"
             >
               <svg
                 aria-hidden="true"
@@ -914,17 +44,24 @@ Array [
                 />
               </svg>
             </span>
-          </th>
-          <th
-            onClick={[Function]}
-          >
-            Unsortable column
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
+          </span>
+        </th>
+        <th
+          onClick={[Function]}
+        >
+          <span>
+            Unsortable column     
+          </span>
+        </th>
+        <th
+          className="filler"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <span>
             <div
               onClick={[Function]}
               style={
@@ -982,13 +119,20 @@ Array [
               </svg>
             </div>
             parent
-          </td>
-          <td>
+          </span>
+        </td>
+        <td>
+          <span>
             parent second column
-          </td>
-        </tr>
-        <tr>
-          <td>
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
             <div
               style={
                 Object {
@@ -1026,13 +170,20 @@ Array [
               </svg>
             </div>
             child1
-          </td>
-          <td>
+          </span>
+        </td>
+        <td>
+          <span>
             child1 second column
-          </td>
-        </tr>
-        <tr>
-          <td>
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
             <div
               onClick={[Function]}
               style={
@@ -1090,13 +241,20 @@ Array [
               </svg>
             </div>
             child2
-          </td>
-          <td>
+          </span>
+        </td>
+        <td>
+          <span>
             child2 second column
-          </td>
-        </tr>
-        <tr>
-          <td>
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
             <div
               style={
                 Object {
@@ -1134,13 +292,20 @@ Array [
               </svg>
             </div>
             grandchild1
-          </td>
-          <td>
+          </span>
+        </td>
+        <td>
+          <span>
             grandchild1 second column
-          </td>
-        </tr>
-        <tr>
-          <td>
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
             <div
               style={
                 Object {
@@ -1178,10 +343,983 @@ Array [
               </svg>
             </div>
             grandchild2
+          </span>
+        </td>
+        <td>
+          <span>
+            grandchild2 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Entry with children Check one grandchild 1`] = `
+<div>
+  <table
+    className="table-tree"
+    style={
+      Object {
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
+      }
+    }
+  >
+    <thead>
+      <tr>
+        <th
+          onClick={[Function]}
+        >
+          <span>
+            Sortable column     
+            <span
+              className="sort-icon"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-sort fa-w-10 "
+                data-icon="sort"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+          </span>
+        </th>
+        <th
+          onClick={[Function]}
+        >
+          <span>
+            Unsortable column     
+          </span>
+        </th>
+        <th
+          className="filler"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <span>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 12,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-minus-square fa-w-14 "
+                data-icon="minus-square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            parent
+          </span>
+        </td>
+        <td>
+          <span>
+            parent second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 24,
+                }
+              }
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            child1
+          </span>
+        </td>
+        <td>
+          <span>
+            child1 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 24,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-minus-square fa-w-14 "
+                data-icon="minus-square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            child2
+          </span>
+        </td>
+        <td>
+          <span>
+            child2 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 36,
+                }
+              }
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-check-square fa-w-14 "
+                data-icon="check-square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            grandchild1
+          </span>
+        </td>
+        <td>
+          <span>
+            grandchild1 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 36,
+                }
+              }
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            grandchild2
+          </span>
+        </td>
+        <td>
+          <span>
+            grandchild2 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Entry with children Collapse one child 1`] = `
+<div>
+  <table
+    className="table-tree"
+    style={
+      Object {
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
+      }
+    }
+  >
+    <thead>
+      <tr>
+        <th
+          onClick={[Function]}
+        >
+          <span>
+            Sortable column     
+            <span
+              className="sort-icon"
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-sort fa-w-10 "
+                data-icon="sort"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
+          </span>
+        </th>
+        <th
+          onClick={[Function]}
+        >
+          <span>
+            Unsortable column     
+          </span>
+        </th>
+        <th
+          className="filler"
+        />
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <span>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 12,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-down fa-w-14 "
+                data-icon="chevron-down"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            parent
+          </span>
+        </td>
+        <td>
+          <span>
+            parent second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 24,
+                }
+              }
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            child1
+          </span>
+        </td>
+        <td>
+          <span>
+            child1 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+      <tr>
+        <td>
+          <span>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "textAlign": "right",
+                  "width": 24,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chevron-right fa-w-10 "
+                data-icon="chevron-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
+              }
+            >
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            child2
+          </span>
+        </td>
+        <td>
+          <span>
+            child2 second column
+          </span>
+        </td>
+        <td
+          className="filler"
+        />
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Entry with children With filter element 1`] = `
+Array [
+  <div
+    onChange={[Function]}
+  >
+    <input
+      id="input-filter-tree"
+      placeholder="Filter"
+      type="text"
+    />
+  </div>,
+  <div>
+    <table
+      className="table-tree"
+      style={
+        Object {
+          "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
+        }
+      }
+    >
+      <thead>
+        <tr>
+          <th
+            onClick={[Function]}
+          >
+            <span>
+              Sortable column     
+              <span
+                className="sort-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-sort fa-w-10 "
+                  data-icon="sort"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 320 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+            </span>
+          </th>
+          <th
+            onClick={[Function]}
+          >
+            <span>
+              Unsortable column     
+            </span>
+          </th>
+          <th
+            className="filler"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <span>
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingRight": 5,
+                    "textAlign": "right",
+                    "width": 12,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline",
+                    "paddingRight": 5,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-square fa-w-14 "
+                  data-icon="square"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              parent
+            </span>
           </td>
           <td>
-            grandchild2 second column
+            <span>
+              parent second column
+            </span>
           </td>
+          <td
+            className="filler"
+          />
+        </tr>
+        <tr>
+          <td>
+            <span>
+              <div
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingRight": 5,
+                    "width": 24,
+                  }
+                }
+              />
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline",
+                    "paddingRight": 5,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-square fa-w-14 "
+                  data-icon="square"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              child1
+            </span>
+          </td>
+          <td>
+            <span>
+              child1 second column
+            </span>
+          </td>
+          <td
+            className="filler"
+          />
+        </tr>
+        <tr>
+          <td>
+            <span>
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingRight": 5,
+                    "textAlign": "right",
+                    "width": 24,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chevron-down fa-w-14 "
+                  data-icon="chevron-down"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline",
+                    "paddingRight": 5,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-square fa-w-14 "
+                  data-icon="square"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              child2
+            </span>
+          </td>
+          <td>
+            <span>
+              child2 second column
+            </span>
+          </td>
+          <td
+            className="filler"
+          />
+        </tr>
+        <tr>
+          <td>
+            <span>
+              <div
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingRight": 5,
+                    "width": 36,
+                  }
+                }
+              />
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline",
+                    "paddingRight": 5,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-square fa-w-14 "
+                  data-icon="square"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              grandchild1
+            </span>
+          </td>
+          <td>
+            <span>
+              grandchild1 second column
+            </span>
+          </td>
+          <td
+            className="filler"
+          />
+        </tr>
+        <tr>
+          <td>
+            <span>
+              <div
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "paddingRight": 5,
+                    "width": 36,
+                  }
+                }
+              />
+              <div
+                onClick={[Function]}
+                style={
+                  Object {
+                    "display": "inline",
+                    "paddingRight": 5,
+                  }
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-square fa-w-14 "
+                  data-icon="square"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </div>
+              grandchild2
+            </span>
+          </td>
+          <td>
+            <span>
+              grandchild2 second column
+            </span>
+          </td>
+          <td
+            className="filler"
+          />
         </tr>
       </tbody>
     </table>
@@ -1195,7 +1333,7 @@ exports[`one level of entries 1`] = `
     className="table-tree"
     style={
       Object {
-        "borderCollapse": "collapse",
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
       }
     }
   >
@@ -1204,74 +1342,91 @@ exports[`one level of entries 1`] = `
         <th
           onClick={[Function]}
         >
-          Sortable column
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sort fa-w-10 "
-              data-icon="sort"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
+          <span>
+            Sortable column     
+            <span
+              className="sort-icon"
             >
-              <path
-                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-sort fa-w-10 "
+                data-icon="sort"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
           </span>
         </th>
         <th
           onClick={[Function]}
         >
-          Unsortable column
+          <span>
+            Unsortable column     
+          </span>
         </th>
+        <th
+          className="filler"
+        />
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          entry1
+            />
+            entry1
+          </span>
         </td>
         <td>
-          
+          <span>
+            
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          entry2
+            />
+            entry2
+          </span>
         </td>
         <td>
-          entry2 column2
+          <span>
+            entry2 column2
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
     </tbody>
   </table>
@@ -1284,7 +1439,7 @@ exports[`one level of entries 2`] = `
     className="table-tree"
     style={
       Object {
-        "borderCollapse": "collapse",
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
       }
     }
   >
@@ -1293,128 +1448,145 @@ exports[`one level of entries 2`] = `
         <th
           onClick={[Function]}
         >
-          Sortable column
-          <span
-            style={
-              Object {
-                "float": "right",
-              }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sort fa-w-10 "
-              data-icon="sort"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 320 512"
-              xmlns="http://www.w3.org/2000/svg"
+          <span>
+            Sortable column     
+            <span
+              className="sort-icon"
             >
-              <path
-                d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-sort fa-w-10 "
+                data-icon="sort"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </span>
           </span>
         </th>
         <th
           onClick={[Function]}
         >
-          Unsortable column
+          <span>
+            Unsortable column     
+          </span>
         </th>
+        <th
+          className="filler"
+        />
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
               }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-          </div>
-          entry1
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            entry1
+          </span>
         </td>
         <td>
-          
+          <span>
+            
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
               }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-          </div>
-          entry2
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            entry2
+          </span>
         </td>
         <td>
-          entry2 column2
+          <span>
+            entry2 column2
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
     </tbody>
   </table>
@@ -1427,98 +1599,112 @@ exports[`one level of entries 3`] = `
     className="table-tree"
     style={
       Object {
-        "borderCollapse": "collapse",
+        "gridTemplateColumns": "max-content max-content minmax(0px, 1fr)",
       }
     }
   >
     <tbody>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
               }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-          </div>
-          entry1
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            entry1
+          </span>
         </td>
         <td>
-          
+          <span>
+            
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
       <tr>
         <td>
-          <div
-            style={
-              Object {
-                "display": "inline-block",
-                "paddingRight": 5,
-                "width": 12,
+          <span>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                  "paddingRight": 5,
+                  "width": 12,
+                }
               }
-            }
-          />
-          <div
-            onClick={[Function]}
-            style={
-              Object {
-                "display": "inline",
-                "paddingRight": 5,
+            />
+            <div
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "inline",
+                  "paddingRight": 5,
+                }
               }
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-square fa-w-14 "
-              data-icon="square"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-square fa-w-14 "
+                data-icon="square"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
                 style={Object {}}
-              />
-            </svg>
-          </div>
-          entry2
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            entry2
+          </span>
         </td>
         <td>
-          entry2 column2
+          <span>
+            entry2 column2
+          </span>
         </td>
+        <td
+          className="filler"
+        />
       </tr>
     </tbody>
   </table>

--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/table-row.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/table-row.test.tsx.snap
@@ -3,220 +3,245 @@
 exports[`Checked status 1`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 12,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 12,
+          }
         }
-      }
-    />
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
+      />
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "inline",
+            "paddingRight": 5,
+          }
         }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-square fa-w-14 "
-        data-icon="square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-square fa-w-14 "
+          data-icon="square"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </div>
-    cell1 - text
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </div>
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
 exports[`Checked status 2`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 12,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 12,
+          }
         }
-      }
-    />
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
+      />
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "inline",
+            "paddingRight": 5,
+          }
         }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-check-square fa-w-14 "
-        data-icon="check-square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-check-square fa-w-14 "
+          data-icon="check-square"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </div>
-    cell1 - text
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </div>
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
 exports[`Checked status 3`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 12,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 12,
+          }
         }
-      }
-    />
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
+      />
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "inline",
+            "paddingRight": 5,
+          }
         }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-minus-square fa-w-14 "
-        data-icon="minus-square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-minus-square fa-w-14 "
+          data-icon="minus-square"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </div>
-    cell1 - text
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </div>
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
 exports[`Levels 1`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 24,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 24,
+          }
         }
-      }
-    />
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
+      />
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "inline",
+            "paddingRight": 5,
+          }
         }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-square fa-w-14 "
-        data-icon="square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-square fa-w-14 "
+          data-icon="square"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </div>
-    cell1 - text
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </div>
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
 exports[`Levels 2`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 132,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 132,
+          }
         }
-      }
-    />
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
+      />
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "inline",
+            "paddingRight": 5,
+          }
         }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-square fa-w-14 "
-        data-icon="square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-          fill="currentColor"
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-square fa-w-14 "
+          data-icon="square"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
           style={Object {}}
-        />
-      </svg>
-    </div>
-    cell1 - text
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+      </div>
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
@@ -224,155 +249,176 @@ exports[`Multiple labels With children and labels 1`] = `
 Array [
   <tr>
     <td>
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline-block",
-            "paddingRight": 5,
-            "textAlign": "right",
-            "width": 12,
+      <span>
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "textAlign": "right",
+              "width": 12,
+            }
           }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-chevron-down fa-w-14 "
-          data-icon="chevron-down"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
-            fill="currentColor"
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-chevron-down fa-w-14 "
+            data-icon="chevron-down"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={Object {}}
-          />
-        </svg>
-      </div>
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "paddingRight": 5,
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
           }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-square fa-w-14 "
-          data-icon="square"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-            fill="currentColor"
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={Object {}}
-          />
-        </svg>
-      </div>
-      parent 1 text
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        parent 1 text
+      </span>
     </td>
     <td>
-      parent 2 text
+      <span>
+        parent 2 text
+      </span>
     </td>
+    <td
+      className="filler"
+    />
   </tr>,
   <tr>
     <td>
-      <div
-        style={
-          Object {
-            "display": "inline-block",
-            "paddingRight": 5,
-            "width": 24,
+      <span>
+        <div
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "width": 24,
+            }
           }
-        }
-      />
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "paddingRight": 5,
+        />
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
           }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-square fa-w-14 "
-          data-icon="square"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-            fill="currentColor"
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={Object {}}
-          />
-        </svg>
-      </div>
-      child1
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        child1
+      </span>
     </td>
     <td>
-      child 1 text
+      <span>
+        child 1 text
+      </span>
     </td>
+    <td
+      className="filler"
+    />
   </tr>,
   <tr>
     <td>
-      <div
-        style={
-          Object {
-            "display": "inline-block",
-            "paddingRight": 5,
-            "width": 24,
+      <span>
+        <div
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "width": 24,
+            }
           }
-        }
-      />
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "paddingRight": 5,
+        />
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
           }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-square fa-w-14 "
-          data-icon="square"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-            fill="currentColor"
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={Object {}}
-          />
-        </svg>
-      </div>
-      child2
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        child2
+      </span>
     </td>
     <td>
-      child 2 text
+      <span>
+        child 2 text
+      </span>
     </td>
+    <td
+      className="filler"
+    />
   </tr>,
 ]
 `;
@@ -380,17 +426,22 @@ Array [
 exports[`Uncheckable 1`] = `
 <tr>
   <td>
-    <div
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "width": 12,
+    <span>
+      <div
+        style={
+          Object {
+            "display": "inline-block",
+            "paddingRight": 5,
+            "width": 12,
+          }
         }
-      }
-    />
-    cell1 - text
+      />
+      cell1 - text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;
 
@@ -398,6 +449,169 @@ exports[`with children With children 1`] = `
 Array [
   <tr>
     <td>
+      <span>
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "textAlign": "right",
+              "width": 12,
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-chevron-down fa-w-14 "
+            data-icon="chevron-down"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        parent text
+      </span>
+    </td>
+    <td
+      className="filler"
+    />
+  </tr>,
+  <tr>
+    <td>
+      <span>
+        <div
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "width": 24,
+            }
+          }
+        />
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        child 1 text
+      </span>
+    </td>
+    <td
+      className="filler"
+    />
+  </tr>,
+  <tr>
+    <td>
+      <span>
+        <div
+          style={
+            Object {
+              "display": "inline-block",
+              "paddingRight": 5,
+              "width": 24,
+            }
+          }
+        />
+        <div
+          onClick={[Function]}
+          style={
+            Object {
+              "display": "inline",
+              "paddingRight": 5,
+            }
+          }
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-square fa-w-14 "
+            data-icon="square"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
+        child 2 text
+      </span>
+    </td>
+    <td
+      className="filler"
+    />
+  </tr>,
+]
+`;
+
+exports[`with children With children collapsed 1`] = `
+<tr>
+  <td>
+    <span>
       <div
         onClick={[Function]}
         style={
@@ -411,17 +625,17 @@ Array [
       >
         <svg
           aria-hidden="true"
-          className="svg-inline--fa fa-chevron-down fa-w-14 "
-          data-icon="chevron-down"
+          className="svg-inline--fa fa-chevron-right fa-w-10 "
+          data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
           role="img"
           style={Object {}}
-          viewBox="0 0 448 512"
+          viewBox="0 0 320 512"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+            d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
             fill="currentColor"
             style={Object {}}
           />
@@ -455,153 +669,10 @@ Array [
         </svg>
       </div>
       parent text
-    </td>
-  </tr>,
-  <tr>
-    <td>
-      <div
-        style={
-          Object {
-            "display": "inline-block",
-            "paddingRight": 5,
-            "width": 24,
-          }
-        }
-      />
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "paddingRight": 5,
-          }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-square fa-w-14 "
-          data-icon="square"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-      </div>
-      child 1 text
-    </td>
-  </tr>,
-  <tr>
-    <td>
-      <div
-        style={
-          Object {
-            "display": "inline-block",
-            "paddingRight": 5,
-            "width": 24,
-          }
-        }
-      />
-      <div
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "paddingRight": 5,
-          }
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-square fa-w-14 "
-          data-icon="square"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 448 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-            fill="currentColor"
-            style={Object {}}
-          />
-        </svg>
-      </div>
-      child 2 text
-    </td>
-  </tr>,
-]
-`;
-
-exports[`with children With children collapsed 1`] = `
-<tr>
-  <td>
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline-block",
-          "paddingRight": 5,
-          "textAlign": "right",
-          "width": 12,
-        }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-chevron-right fa-w-10 "
-        data-icon="chevron-right"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 320 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </div>
-    <div
-      onClick={[Function]}
-      style={
-        Object {
-          "display": "inline",
-          "paddingRight": 5,
-        }
-      }
-    >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-square fa-w-14 "
-        data-icon="square"
-        data-prefix="fas"
-        focusable="false"
-        role="img"
-        style={Object {}}
-        viewBox="0 0 448 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48z"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </div>
-    parent text
+    </span>
   </td>
+  <td
+    className="filler"
+  />
 </tr>
 `;

--- a/packages/react-components/src/components/utils/filtrer-tree/column-header.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/column-header.tsx
@@ -1,5 +1,6 @@
 export default interface ColumnHeader {
     title: string,
     tooltip?: string,
-    sortable?: boolean
+    sortable?: boolean,
+    resizable?: boolean
 }

--- a/packages/react-components/src/components/utils/filtrer-tree/table-cell.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/table-cell.tsx
@@ -15,8 +15,10 @@ export class TableCell extends React.Component<TableCellProps> {
         const content = this.props.node.labels[this.props.index];
         return (
             <td key={this.props.index+'-td-'+this.props.node.id}>
-                {this.props.children}
-                {content}
+                <span>
+                    {this.props.children}
+                    {content}
+                </span>
             </td>
         );
     }

--- a/packages/react-components/src/components/utils/filtrer-tree/table-header.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/table-header.tsx
@@ -10,32 +10,101 @@ interface TableHeaderProps {
 }
 
 export class TableHeader extends React.Component<TableHeaderProps> {
+    private mouseDownX = 0;
+    private originalWidth = 0;
+    private resizedHeader: HTMLElement | undefined = undefined;
+    private resizedIndex = 0;
+    private gridTemplateColumns: string[];
+
     constructor(props: TableHeaderProps) {
         super(props);
+        this.gridTemplateColumns = this.props.columns.map(() => 'max-content');
+        this.gridTemplateColumns.push('minmax(0px, 1fr)');
     }
 
-    handleSortChange = (sortColumn: string): void => {
+    handleSortChange = (sortColumn: string, ev: React.MouseEvent<HTMLTableCellElement, MouseEvent>): void => {
+        const resizeHandle = ev.currentTarget.querySelector('.resize-handle');
+        if (resizeHandle && ev.clientX >= resizeHandle.getBoundingClientRect().x) {
+            /* Don't sort if click is over the resize handle */
+            return;
+        }
         this.props.onSort(sortColumn);
     };
 
-    toCapitalCase = (name: string): string => (name.charAt(0).toUpperCase() + name.slice(1));
+    handleResizeDoubleClick = (ev: React.MouseEvent<HTMLSpanElement, MouseEvent>, index: number): void => {
+        if (ev.currentTarget.parentElement?.parentElement) {
+            const resizedHeader = ev.currentTarget.parentElement?.parentElement;
+            const table = resizedHeader.parentElement?.parentElement?.parentElement;
+            if (table) {
+                this.gridTemplateColumns[index] = 'max-content';
+                table.style.gridTemplateColumns = this.gridTemplateColumns.join(' ');
+            }
+        }
+    };
+
+    handleResizeMouseDown = (ev: React.MouseEvent<HTMLSpanElement, MouseEvent>, index: number): void => {
+        if (ev.currentTarget.parentElement?.parentElement) {
+            this.resizedHeader = ev.currentTarget.parentElement?.parentElement;
+            this.resizedIndex = index;
+            this.mouseDownX = ev.clientX;
+            this.originalWidth = this.resizedHeader.clientWidth;
+            window.addEventListener('mousemove', this.handleResizeMouseMove);
+            window.addEventListener('mouseup', this.handleResizeMouseUp);
+            ev.preventDefault();
+        }
+    };
+
+    handleResizeMouseMove = (ev: MouseEvent): void => {
+        if (this.resizedHeader) {
+            const table = this.resizedHeader.parentElement?.parentElement?.parentElement;
+            if (table) {
+                const width = Math.max(18, this.originalWidth + ev.clientX - this.mouseDownX);
+                this.gridTemplateColumns[this.resizedIndex] = width + 'px';
+                table.style.gridTemplateColumns = this.gridTemplateColumns.join(' ');
+            }
+        }
+    };
+
+    handleResizeMouseUp = (): void => {
+        window.removeEventListener('mousemove', this.handleResizeMouseMove);
+        window.removeEventListener('mouseup', this.handleResizeMouseUp);
+        this.resizedHeader = undefined;
+        this.resizedIndex = 0;
+        this.mouseDownX = 0;
+        this.originalWidth = 0;
+    };
+
+    /* Capitalize first character and add non-breaking spaces to make room for icons in default width calcluation */
+    toHeaderTitle = (name: string): string => (name.charAt(0).toUpperCase() + name.slice(1) + '\xa0\xa0\xa0\xa0\xa0');
 
     renderSortIcon = (column: string): React.ReactNode | undefined => {
         if (this.props.sortableColumns.includes(column)) {
             const state = this.props.sortConfig.find((config: SortConfig) => config.column === column);
             return state
-                ? <span style={{float: 'right'}}>{state.sortState}</span>
+                ? <span className='sort-icon'>{state.sortState}</span>
                 : undefined;
         }
         return undefined;
     };
 
-    renderHeader = (): React.ReactNode => this.props.columns.map((column: ColumnHeader, index) =>
-        <th key={'th-'+index} onClick={() => this.handleSortChange(column.title)}>
-            {this.toCapitalCase(column.title)}
-            {this.renderSortIcon(column.title)}
-        </th>
-    );
+    renderResizeIcon = (index: number): React.ReactNode =>
+        (this.props.columns[index].resizable)
+            ? <span className='resize-handle' onMouseDown={ev => this.handleResizeMouseDown(ev, index)} onDoubleClick={ev => this.handleResizeDoubleClick(ev, index)}>|</span>
+            : undefined;
+
+    renderHeader = (): React.ReactNode => {
+        const header = this.props.columns.map((column: ColumnHeader, index) =>
+            <th key={'th-'+index} onClick={ev => this.handleSortChange(column.title, ev)}>
+                <span>
+                    {this.toHeaderTitle(column.title)}
+                    {this.renderResizeIcon(index)}
+                    {this.renderSortIcon(column.title)}
+                </span>
+            </th>
+        );
+        header.push(<th key={'th-filler'} className='filler'/>);
+        return header;
+    };
 
     render(): React.ReactNode {
         return <thead>

--- a/packages/react-components/src/components/utils/filtrer-tree/table-row.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/table-row.tsx
@@ -58,13 +58,17 @@ export class TableRow extends React.Component<TableRowProps> {
             ? <div style={{ paddingRight: 5, display: 'inline' }} onClick={this.handleClose}>{icons.close}</div>
             : undefined;
 
-    renderRow = (): React.ReactNode => this.props.node.labels.map((_label: string, index) =>
-        <TableCell key={this.props.node.id + '-' + index} index={index} node={this.props.node}>
-            { (index === 0) ? this.renderToggleCollapse() : undefined }
-            { (index === 0) ? this.renderCheckbox() : undefined }
-            { (index === 0) ? this.renderCloseButton() : undefined }
-        </TableCell>
-    );
+    renderRow = (): React.ReactNode => {
+        const row = this.props.node.labels.map((_label: string, index) =>
+            <TableCell key={this.props.node.id + '-' + index} index={index} node={this.props.node}>
+                { (index === 0) ? this.renderToggleCollapse() : undefined }
+                { (index === 0) ? this.renderCheckbox() : undefined }
+                { (index === 0) ? this.renderCloseButton() : undefined }
+            </TableCell>
+        );
+        row.push(<td key={this.props.node.id + '-filler'} className='filler'/>);
+        return row;
+    };
 
     renderChildren = (): React.ReactNode | undefined => {
         if (this.props.node.children.length && !this.isCollapsed()) {

--- a/packages/react-components/src/components/utils/filtrer-tree/table.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/table.tsx
@@ -55,9 +55,10 @@ export class Table extends React.Component<TableProps> {
     };
 
     render(): JSX.Element {
+        const gridTemplateColumns = this.props.headers.map(() => 'max-content').join(' ').concat(' minmax(0px, 1fr)');
         return (
             <div>
-                <table style={{ borderCollapse: 'collapse' }} className={this.props.className}>
+                <table style={{ gridTemplateColumns: gridTemplateColumns }} className={this.props.className}>
                     {this.props.showHeader && <TableHeader
                         columns={this.props.headers}
                         sortableColumns={this.sortableColumns}

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -105,7 +105,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
                 const columns = [];
                 if (headers && headers.length > 0) {
                     headers.forEach(header => {
-                        columns.push({title: header.name, sortable: true, tooltip: header.tooltip});
+                        columns.push({title: header.name, sortable: true, resizable: true, tooltip: header.tooltip});
                     });
                 } else {
                     columns.push({title: 'Name', sortable: true});

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -97,27 +97,84 @@ canvas {
     align-self: center;
 }
 
-.table-tree>tbody>tr:nth-child(1)>th {
-    background-color: var(--theia-editor-background);
-    position: sticky;
-    top: 0;
+.table-tree {
+    display: grid;
+    border-collapse: collapse;
+    border-left: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
 }
 
-.table-tree th, .table-tree td {
-    padding: 3px 5px;
+.table-tree thead, .table-tree tbody, .table-tree tr {
+    display: contents;
+}
+
+.table-tree th {
+    position: relative;
+    padding: 3px 0px 3px 5px;
+    background-color: var(--theia-list-hoverBackground) !important;
+    border-top: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
+    border-bottom: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
     text-align: left;
-    border-bottom: 1px solid #333;
-    border-right: 1px solid #333;
+}
+
+.table-tree tr:hover td {
+    background-color: var(--theia-list-hoverBackground) !important;
+}
+
+.table-tree td {
+    padding: 3px 5px;
+    border-bottom: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
+    border-right: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
+    text-align: left;
+}
+
+.table-tree th span {
+    overflow: hidden;
     white-space: nowrap;
-    min-width: 50px;
+    display: block;
+}
+
+.table-tree td span {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: block;
+}
+
+.resize-handle {
+    float: right;
+    position: absolute;
+    top: 1px;
+    right: 0px;
+    color: var(--theia-tree-inactiveIndentGuidesStroke);
+    background-color: var(--theia-list-hoverBackground);
+    cursor: col-resize;
+}
+
+.sort-icon {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    padding: 0px 3px;
+    background-color: var(--theia-list-hoverBackground) !important;
+}
+
+.filler {
+    padding: 0px !important;
+    border-right: 1px solid var(--theia-tree-inactiveIndentGuidesStroke);
+}
+
+.timegraph-tree {
+    border: 0px; 
 }
 
 .timegraph-tree tr {
     /* TODO: Fix row alignment, this number is arbitrary, it works [on my machine], but it should match line height in timeline-chart */
     line-height: 18px;
-    position: relative;
-    white-space: nowrap;
-    padding: 0 0;
+}
+
+.timegraph-tree td {
+    padding: 1px;
+    border: 0px; 
 }
 
 #input-filter-tree {


### PR DESCRIPTION
Add resizable property to ColumnHeader model.

Add a resize handle to each resizable column header cell.

Add listeners to resize columns when the handle is dragged, and reset to
preferred column width when the handle is double-clicked.

Add filler column to make table-tree extend to full container width.

Change the table display, styling, borders, and header color.

Make all output component trees use the same base table-tree styling
with only timegraph-tree adding some specific styling overrides.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>
