### PR TITLE
Make filter width match first column width

### DIFF
--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/__snapshots__/entry-tree.test.tsx.snap
@@ -971,6 +971,11 @@ Array [
     <input
       id="input-filter-tree"
       placeholder="Filter"
+      style={
+        Object {
+          "width": 0,
+        }
+      }
       type="text"
     />
   </div>,

--- a/packages/react-components/src/components/utils/filtrer-tree/__tests__/entry-tree.test.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/__tests__/entry-tree.test.tsx
@@ -84,6 +84,12 @@ test('one level of entries', () => {
     expect(treeWithoutHeaders).toMatchSnapshot();
 });
 
+window.ResizeObserver = window.ResizeObserver || jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+}));
+
 describe('Entry with children', () => {
     const parent = {
         id: 0,

--- a/packages/react-components/src/components/utils/filtrer-tree/filter.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/filter.tsx
@@ -4,17 +4,45 @@ interface FilterProps {
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export class Filter extends React.Component<FilterProps> {
+interface FilterState {
+    width: number
+}
+export class Filter extends React.Component<FilterProps, FilterState> {
+
+    private ref: React.RefObject<HTMLDivElement>;
+    private resizeObserver: ResizeObserver;
+
     constructor(props: FilterProps) {
         super(props);
+        this.ref = React.createRef();
+        this.state = {
+            width: 0
+        };
+        this.resizeObserver = new ResizeObserver(entries => {
+            this.setState({
+                width: entries[0].contentRect.width
+            });
+        });
+    }
+
+    componentDidMount(): void {
+        const header = this.ref.current?.parentElement?.querySelector('th');
+        if (header) {
+            this.resizeObserver.observe(header);
+        }
+    }
+
+    componentWillUnmount(): void {
+        this.resizeObserver.disconnect();
     }
 
     render(): JSX.Element {
-        return <div onChange={this.props.onChange}>
+        return <div ref={this.ref} onChange={this.props.onChange}>
             <input
                 id="input-filter-tree"
                 type="text"
                 placeholder="Filter"
+                style={{width: this.state.width}}
             />
         </div>;
     }

--- a/packages/react-components/src/components/utils/filtrer-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filtrer-tree/tree.tsx
@@ -243,10 +243,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
 
     renderFilterTree = (): JSX.Element => <React.Fragment>
         <Filter onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.handleFilterChanged(e.target.value)} />
-        {this.state.filteredNodes.length
-            ? this.renderTable(this.state.filteredNodes)
-            : <span>No entries found</span>
-        }
+        {this.renderTable(this.state.filteredNodes)}
     </React.Fragment>;
 
     renderTable = (nodes: TreeNode[]): JSX.Element =>

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -182,7 +182,6 @@ canvas {
     border: none;
     border-bottom: 1px solid var(--theia-input-foreground);
     padding: 3px;
-    width: 180px;
     color: var(--theia-input-placeholder-foreground)
 }
 


### PR DESCRIPTION
Add resize observer on first column header to synchronize filter width.

Remove text message on empty filter result as this disrupts the observer
and prevents synchronization after the non-matching filter is removed.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>