### PR TITLE
Display loading message on data tree components

### DIFF
--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -85,11 +85,17 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     }
     renderMainArea(): React.ReactNode {
         return <React.Fragment>
-            <div ref={this.treeRef} className='output-component-tree'
-                style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}
-            >
-                {this.renderTree()}
-            </div>
+            {this.state.outputStatus === ResponseStatus.COMPLETED ?
+                <div ref={this.treeRef} className='output-component-tree'
+                    style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}
+                >
+                    {this.renderTree()}
+                </div> :
+                <div className='analysis-running-main-area'>
+                    <i className='fa fa-refresh fa-spin' style={{ marginRight: '5px' }} />
+                    <span>Analysis running</span>
+                </div>
+            }
         </React.Fragment>;
     }
     private onToggleCollapse(id: number, nodes: TreeNode[]) {
@@ -117,6 +123,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
             await new Promise(resolve => setTimeout(resolve, timeout));
         }
     }
+
     componentWillUnmount(): void {
         // fix Warning: Can't perform a React state update on an unmounted component
         this.setState = (_state, _callback) => undefined;

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -87,6 +87,11 @@ canvas {
     align-self: center;
 }
 
+.analysis-running-main-area {
+    font-size: 24px;
+    margin: auto;
+}
+
 .no-data {
     font-size: 24px;
     text-align: center;


### PR DESCRIPTION
While the data tree component is loading data, display an "analysis
running" message in the middle of the component.

The data tree components are still hidden, as metioned in #598.

Contributes to #144.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>