### PR TITLE
Add horizontal resize sash to output components

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -39,6 +39,7 @@ export interface AbstractOutputProps {
     onMouseDown?: VoidFunction;
     onTouchStart?: VoidFunction;
     onTouchEnd?: VoidFunction;
+    setSashOffset?: (sashOffset: number) => void;
 }
 
 export interface AbstractOutputState {
@@ -49,7 +50,6 @@ export interface AbstractOutputState {
 export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
 
     private mainAreaContainer: React.RefObject<HTMLDivElement>;
-    private readonly HANDLE_WIDTH = 30;
 
     constructor(props: P) {
         super(props);
@@ -70,11 +70,11 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             onTouchEnd={this.props.onTouchEnd}
             data-tip=''
             data-for="tooltip-component">
-            <div className='widget-handle' style={{ width: this.HANDLE_WIDTH, height: this.props.style.height }}>
+            <div className='widget-handle' style={{ width: this.props.style.handleWidth, height: this.props.style.height }}>
                 {this.renderTitleBar()}
             </div>
             <div className='main-output-container' ref={this.mainAreaContainer}
-                style={{ width: this.props.widthWPBugWorkaround - this.HANDLE_WIDTH, height: this.props.style.height }}>
+                style={{ width: this.props.widthWPBugWorkaround - this.props.style.handleWidth, height: this.props.style.height }}>
                 {this.renderMainArea()}
             </div>
             {this.props.children}
@@ -101,11 +101,11 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         if (this.mainAreaContainer.current) {
             return this.mainAreaContainer.current.clientWidth;
         }
-        return 0;
+        return this.props.widthWPBugWorkaround - this.props.style.handleWidth;
     }
 
     public getHandleWidth(): number {
-        return this.HANDLE_WIDTH;
+        return this.props.style.handleWidth;
     }
 
     abstract renderMainArea(): React.ReactNode;

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -3,17 +3,25 @@ import * as React from 'react';
 import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 
 export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends AbstractOutputComponent<P, S> {
+
+    private sashDownX = -1;
+    private sashDownOffset = -1;
+
+    constructor(props: P) {
+        super(props);
+        this.onSashDown = this.onSashDown.bind(this);
+        this.onSashMove = this.onSashMove.bind(this);
+        this.onSashUp = this.onSashUp.bind(this);
+    }
+
     renderMainArea(): React.ReactNode {
         if (this.state.outputStatus === ResponseStatus.FAILED) {
             return this.analysisFailedMessage();
         }
 
-        // Make tree thiner when chart has a y-axis
-        const yAxisBuffer = this.props.outputDescriptor.type === 'TREE_TIME_XY' ? this.props.style.yAxisWidth: 0;
-        const treeWidth = this.getMainAreaWidth() - this.props.style.chartWidth - yAxisBuffer;
         return <React.Fragment>
             <div ref={this.treeRef} className='output-component-tree'
-                style={{ width: treeWidth, height: this.props.style.height }}
+                style={{ width: this.getTreeWidth(), height: this.props.style.height }}
             >
                 {this.renderTree()}
             </div>
@@ -23,13 +31,38 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
             }}>
                 {this.renderYAxis()}
             </div>
+            <div className='output-component-sash' onMouseDown={event => this.onSashDown(event)} style={{
+                width: this.props.style.sashWidth, height: this.props.style.height
+            }}/>
             <div className='output-component-chart' style={{
-                width: this.props.style.chartWidth, height: this.props.style.height,
+                width: this.getChartWidth(), height: this.props.style.height,
                 backgroundColor: '#' + this.props.style.chartBackgroundColor.toString(16)
             }}>
                 {this.renderChart()}
             </div>
         </React.Fragment>;
+    }
+
+    private onSashDown(event: React.MouseEvent<HTMLDivElement, MouseEvent>): void {
+        this.sashDownX = event.clientX;
+        this.sashDownOffset = this.props.style.sashOffset;
+        window.addEventListener('mousemove', this.onSashMove);
+        window.addEventListener('mouseup', this.onSashUp);
+}
+
+    private onSashMove(ev: MouseEvent): void {
+        if (this.sashDownX !== -1 && this.props?.setSashOffset) {
+            const sashOffset = Math.max(this.props.style.yAxisWidth, this.sashDownOffset + (ev.clientX - this.sashDownX));
+            this.props.setSashOffset(sashOffset);
+            ev.preventDefault();
+        }
+    }
+
+    private onSashUp(_ev: MouseEvent): void {
+        this.sashDownX = -1;
+        this.sashDownOffset = -1;
+        window.removeEventListener('mousemove', this.onSashMove);
+        window.removeEventListener('mouseup', this.onSashUp);
     }
 
     treeRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -55,5 +88,15 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
         // fix Warning: Can't perform a React state update on an unmounted component
         this.setState = (_state, _callback) => undefined;
 
+    }
+
+    public getTreeWidth(): number {
+        // Make tree thinner when chart has a y-axis
+        const yAxisBuffer = this.props.outputDescriptor.type === 'TREE_TIME_XY' ? this.props.style.yAxisWidth: 0;
+        return Math.min(this.getMainAreaWidth(), this.props.style.sashOffset - yAxisBuffer);
+    }
+
+    public getChartWidth(): number {
+        return Math.max(0, this.getMainAreaWidth() - this.props.style.sashOffset - this.props.style.sashWidth);
     }
 }

--- a/packages/react-components/src/components/null-output-component.tsx
+++ b/packages/react-components/src/components/null-output-component.tsx
@@ -12,14 +12,15 @@ export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps
         super(props);
     }
     renderMainArea(): React.ReactNode {
-        const treeWidth = this.props.widthWPBugWorkaround - this.getHandleWidth() - this.props.style.chartWidth;
+        const treeWidth = Math.min(this.getMainAreaWidth(), this.props.style.sashOffset + this.props.style.sashWidth);
+        const chartWidth = this.getMainAreaWidth() - treeWidth;
         return <React.Fragment>
             <div className='output-component-tree'
                 style={{ width: treeWidth, height: this.props.style.height }}
             >
                 {''}
             </div>
-            <div className='output-component-chart' style={{ fontSize: 24, width: this.props.style.chartWidth, height: this.props.style.height, backgroundColor: '#3f3f3f', }}>
+            <div className='output-component-chart' style={{ fontSize: 24, width: chartWidth, height: this.props.style.height, backgroundColor: '#3f3f3f', }}>
                 {'Not implemented yet!'}
             </div>
         </React.Fragment>;

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -421,7 +421,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 {
                     id: 'timegraph-chart-1',
                     height: this.getMarkersLayerHeight(),
-                    width: this.props.style.chartWidth,
+                    width: this.getChartWidth(),
                     backgroundColor: this.props.style.chartBackgroundColor,
                     lineColor: this.props.style.lineColor,
                     classNames: 'horizontal-canvas'
@@ -445,7 +445,7 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
                 {
                     id: 'timegraph-chart',
                     height: parseInt(this.props.style.height.toString()) - this.getMarkersLayerHeight(),
-                    width: this.props.style.chartWidth, // this.props.style.mainWidth,
+                    width: this.getChartWidth(),
                     backgroundColor: this.props.style.chartBackgroundColor,
                     lineColor: this.props.backgroundTheme === 'light' ? 0xdddddd : 0x34383C,
                     classNames: 'horizontal-canvas'

--- a/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
+++ b/packages/react-components/src/components/utils/__tests__/time-axis-component.test.tsx
@@ -11,8 +11,10 @@ describe('Time axis component', () => {
   it('renders with provided style', () => {
     const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
     const style: OutputComponentStyle = {
-      width: 50,
-      chartWidth: 60,
+      width: 600,
+      handleWidth: 40,
+      sashOffset: 200,
+      sashWidth: 4,
       yAxisWidth: 30,
       componentLeft: 0,
       height: 100,
@@ -30,8 +32,10 @@ describe('Time axis component', () => {
   it('creates canvas', () => {
     const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
     const style: OutputComponentStyle = {
-      width: 50,
-      chartWidth: 60,
+      width: 600,
+      handleWidth: 40,
+      sashOffset: 200,
+      sashWidth: 4,
       yAxisWidth: 30,
       componentLeft: 0,
       height: 100,

--- a/packages/react-components/src/components/utils/__tests__/time-navigator-component.test.tsx
+++ b/packages/react-components/src/components/utils/__tests__/time-navigator-component.test.tsx
@@ -10,7 +10,10 @@ describe('Time axis component', () => {
   it('renders with provided style', () => {
     const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
     const style = {
-      chartWidth: 60,
+      width: 600,
+      handleWidth: 40,
+      sashOffset: 200,
+      sashWidth: 4,
       naviBackgroundColor: 0xf4f7fb,
       cursorColor: 0x259fd8,
       lineColor: 0x757575
@@ -23,7 +26,10 @@ describe('Time axis component', () => {
   it('creates canvas', () => {
     const unitController: TimeGraphUnitController = new TimeGraphUnitController(BigInt(10), { start: BigInt(0), end: BigInt(10)});
     const style = {
-      chartWidth: 60,
+      width: 600,
+      handleWidth: 40,
+      sashOffset: 200,
+      sashWidth: 4,
       naviBackgroundColor: 0xf4f7fb,
       cursorColor: 0x259fd8,
       lineColor: 0x757575

--- a/packages/react-components/src/components/utils/output-component-style.ts
+++ b/packages/react-components/src/components/utils/output-component-style.ts
@@ -1,8 +1,10 @@
 export interface OutputComponentStyle {
     width: number;
-    chartWidth: number;
+    handleWidth: number;
+    sashOffset: number;
+    sashWidth: number;
     yAxisWidth: number;
-    componentLeft: number,
+    componentLeft: number;
     // react-grid-layout - The library used for resizing components
     // inserts new React components during compilation, and the dimensions
     // it returns are strings (pixels).

--- a/packages/react-components/src/components/utils/time-axis-component.tsx
+++ b/packages/react-components/src/components/utils/time-axis-component.tsx
@@ -19,7 +19,7 @@ export class TimeAxisComponent extends React.Component<TimeAxisProps> {
             options={{
                 id: 'timegraph-axis',
                 height: 30,
-                width: this.props.style.chartWidth,
+                width: this.props.style.width - this.props.style.handleWidth - this.props.style.sashOffset - this.props.style.sashWidth,
                 backgroundColor: this.props.style.chartBackgroundColor,
                 lineColor: this.props.style.lineColor,
                 classNames: 'horizontal-canvas'

--- a/packages/react-components/src/components/utils/time-navigator-component.tsx
+++ b/packages/react-components/src/components/utils/time-navigator-component.tsx
@@ -6,7 +6,10 @@ import { TimeGraphNavigator } from 'timeline-chart/lib/layer/time-graph-navigato
 interface TimeNavigatorProps {
     unitController: TimeGraphUnitController;
     style: {
-        chartWidth: number,
+        width: number,
+        handleWidth: number,
+        sashOffset: number,
+        sashWidth: number,
         naviBackgroundColor: number,
         cursorColor: number,
         lineColor: number
@@ -21,7 +24,7 @@ export class TimeNavigatorComponent extends React.Component<TimeNavigatorProps> 
         return <ReactTimeGraphContainer
             id='time-navigator'
             options={{
-                width: this.props.style.chartWidth,
+                width: this.props.style.width - this.props.style.handleWidth - this.props.style.sashOffset - this.props.style.sashWidth,
                 height: 10,
                 id: 'time-navigator',
                 backgroundColor: this.props.style.naviBackgroundColor,

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -150,7 +150,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         const viewRangeChanged = this.props.viewRange !== prevProps.viewRange;
         const checkedSeriesChanged = this.state.checkedSeries !== prevState.checkedSeries;
         const collapsedNodesChanged = this.state.collapsedNodes !== prevState.collapsedNodes;
-        const chartWidthChanged = this.props.style.chartWidth !== prevProps.style.chartWidth;
+        const chartWidthChanged = this.props.style.width !== prevProps.style.width || this.props.style.sashOffset !== prevProps.style.sashOffset;
         const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged;
         if (needToUpdate || prevState.outputStatus === ResponseStatus.RUNNING) {
             this.updateXY();
@@ -730,7 +730,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         }
 
         const xyDataParameters = QueryHelper.selectionTimeQuery(
-            QueryHelper.splitRangeIntoEqualParts(start, end, this.props.style.chartWidth), this.state.checkedSeries);
+            QueryHelper.splitRangeIntoEqualParts(start, end, this.getChartWidth()), this.state.checkedSeries);
 
         const tspClientResponse = await this.props.tspClient.fetchXY(this.props.traceId, this.props.outputDescriptor.id, xyDataParameters);
         const xyDataResponse = tspClientResponse.getModel();

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -44,6 +44,15 @@
     white-space: pre-wrap;
 }
 
+.output-component-sash {
+    background-color: var(--theia-list-hoverBackground);
+    cursor: col-resize;
+}
+
+.output-component-sash:hover {
+    background-color: steelblue;
+}
+
 .output-component-chart {
     align-self: center;
     text-align: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10096,7 +10096,7 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
-"json-bigint@github:sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473":
+json-bigint@sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473:
   version "1.0.0"
   resolved "https://codeload.github.com/sidorares/json-bigint/tar.gz/2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473"
   dependencies:


### PR DESCRIPTION
Add a sash between the tree and the chart. For XY chart insert the sash
between the Y-axis and the chart.

Add mouse handling to the sash to call the setSashOffset() callback when
moving the mouse while the sash is clicked, to propage the new sash
offset to all output components.

Refactor the width handling to use handle width, sash offset and sash
width to compute the tree width and chart width.

Add hover color and cursor to the sash.

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>