### PR TITLE
Table, Timegraph, XY Chart: Display "no results' message

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -117,4 +117,14 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             </div>
         </React.Fragment>;
     }
+
+    protected emptyResultsMessage(): React.ReactFragment {
+        return <React.Fragment>
+                <div className='chart-message'>
+                    Trace analysis complete.
+                    <br />
+                    No results: Trace missing required events.
+                </div>
+        </React.Fragment>;
+    }
 }

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -112,7 +112,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     protected analysisFailedMessage(): React.ReactFragment {
         return <React.Fragment>
-            <div className='analysis-failed-message'>
+            <div className='message-main-area'>
                 Trace analysis failed.
             </div>
         </React.Fragment>;
@@ -120,7 +120,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     protected emptyResultsMessage(): React.ReactFragment {
         return <React.Fragment>
-                <div className='chart-message'>
+                <div className='message-main-area'>
                     Trace analysis complete.
                     <br />
                     No results: Trace missing required events.

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -19,6 +19,10 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
             return this.analysisFailedMessage();
         }
 
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.resultsAreEmpty()) {
+            return this.emptyResultsMessage();
+        }
+
         return <React.Fragment>
             <div ref={this.treeRef} className='output-component-tree'
                 style={{ width: this.getTreeWidth(), height: this.props.style.height }}
@@ -74,6 +78,8 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
     abstract renderChart(): React.ReactNode;
 
     abstract fetchTree(): Promise<ResponseStatus>;
+
+    abstract resultsAreEmpty(): boolean;
 
     protected async waitAnalysisCompletion(): Promise<void> {
         let outputStatus = this.state.outputStatus;

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -101,6 +101,10 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             return this.analysisFailedMessage();
         }
 
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.tableColumns.length === 0) {
+            return this.emptyResultsMessage();
+        }
+
         return <div id='events-table'
             className={this.props.backgroundTheme === 'light' ? 'ag-theme-balham' : 'ag-theme-balham-dark'}
             style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}>

--- a/packages/react-components/src/components/timegraph-output-component.tsx
+++ b/packages/react-components/src/components/timegraph-output-component.tsx
@@ -353,6 +353,10 @@ export class TimegraphOutputComponent extends AbstractTreeOutputComponent<Timegr
         </React.Fragment>;
     }
 
+    resultsAreEmpty(): boolean {
+        return this.state.timegraphTree.length === 0;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async fetchTooltip(element: TimeGraphComponent<any>): Promise<{ [key: string]: string } | undefined> {
         if (element instanceof TimeGraphStateComponent) {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -315,20 +315,18 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         // width={this.props.style.chartWidth}
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0) {
             return <React.Fragment>
-                <div className='no-data'>
-                    Trace analysis completed.
+                <div className='chart-message'>
+                    Trace analysis complete.
                     <br />
                     No results: Trace missing required events.
                 </div>
             </React.Fragment>;
         }
-        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length===0 ) {
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length === 0) {
             return <React.Fragment>
-                {
-                    <p className='no-data' style={{fontSize: 20, marginRight: '5px', marginLeft: '5px', justifyContent:'center', alignItems:'center'}}>
-                        Select a checkbox to see analysis results
-                    </p>
-                }
+                <div className='chart-message'>
+                    Select a checkbox to see analysis results
+                </div>
             </React.Fragment>;
         }
         return <React.Fragment>

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -313,9 +313,6 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
 
     renderChart(): React.ReactNode {
         // width={this.props.style.chartWidth}
-        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0) {
-            return this.emptyResultsMessage();
-        }
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length === 0) {
             return <React.Fragment>
                 <div className='chart-message'>
@@ -349,6 +346,10 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
                     }
                 </div>}
         </React.Fragment>;
+    }
+
+    resultsAreEmpty(): boolean {
+        return this.state.xyTree.length === 0;
     }
 
     private afterChartDraw(chart: Chart) {

--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -314,13 +314,7 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
     renderChart(): React.ReactNode {
         // width={this.props.style.chartWidth}
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyTree.length === 0) {
-            return <React.Fragment>
-                <div className='chart-message'>
-                    Trace analysis complete.
-                    <br />
-                    No results: Trace missing required events.
-                </div>
-            </React.Fragment>;
+            return this.emptyResultsMessage();
         }
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.xyData?.datasets?.length === 0) {
             return <React.Fragment>

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -111,10 +111,10 @@ canvas {
     align-self: center;
 }
 
-.analysis-failed-message {
+.message-main-area {
     font-size: 20px;
-    margin-top: -20px; /* So text is vertically aligned relative to its center rather than its top */
     transform: translate(0, 50%);
+    text-align: center;
     margin-left: auto;
     margin-right: auto;
 }

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -101,8 +101,8 @@ canvas {
     margin: auto;
 }
 
-.no-data {
-    font-size: 24px;
+.chart-message {
+    font-size: 20px;
     text-align: center;
     position: relative;
     transform: translate(0, -50%);


### PR DESCRIPTION
when analysis results are empty.

For all components, display message in the main chart area to keep
visual consistency.

Other details:
* Make CSS class name general since it is being used for several messages
now.
* Change CSS properties to consider text displayed on multiple
lines. The manual margin-top ajustment is a hack that only works for
single line messages.

Generalization of PR theia-ide#447

Fixes theia-ide#406

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>