### PR TITLE
Add dialog for Trace Viewer Keyboard and Mouse Shortcuts

### DIFF
--- a/packages/react-components/style/trace-explorer.css
+++ b/packages/react-components/style/trace-explorer.css
@@ -211,3 +211,77 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.shortcuts-table {
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+@media only screen and (min-width: 768px) {
+    .shortcuts-table {
+        min-width: 700px;
+    }
+}
+
+@media only screen and (min-width: 992px) {
+    .shortcuts-table {
+        min-width: 800px;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    .shortcuts-table {
+        min-width: 1000px;
+    }
+}
+
+.shortcuts-table table {
+    border-spacing: 0;
+    border-collapse: separate;
+    background-color: var(--theia-editor-background);
+    width: 100%;
+}
+
+.shortcuts-table-row {
+    margin-bottom: 10px;
+}
+
+@media only screen and (min-width: 650px) {
+    .shortcuts-table-row {
+        display: flex;
+        margin-left:-5px;
+        margin-right:-5px;
+    }
+
+    .shortcuts-table-column {
+        flex: 50%;
+        padding: 5px 10px 5px 10px;
+    }
+}
+
+.shortcuts-table table tr:nth-child(odd) {
+    background-color: rgba(130, 130, 130, 0.04);
+}
+
+.shortcuts-table-header {
+    padding-top: 5px;
+    padding-left: 5px;
+    text-align: left;
+    vertical-align: middle;
+    background-color: var(--theia-editorWidget-background);
+    font-size: var(--theia-ui-font-size1);
+    min-height: 23px;
+    white-space: nowrap;
+}
+
+.shortcuts-table i {
+    color: var(--theia-button-background);
+}
+
+.shortcuts-table-keybinding {
+    min-height: 23px;
+    vertical-align: middle;
+    align-items: center;
+    justify-content: flex-end !important;
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { inject, injectable, postConstruct } from 'inversify';
+import { Dialog, DialogProps } from '@theia/core/lib/browser/dialogs';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+import { Message } from '@theia/core/lib/browser/widgets/widget';
+import { EssentialShortcutsTable } from './essential-shortcuts-table';
+import { ZoomPanShortcutsTable } from './zoom-pan-shortcuts-table';
+import { TimeGraphShortcutsTable } from './time-graph-navigation-shortcuts-table';
+import { SelectShortcutsTable } from './select-shortcuts-table';
+
+@injectable()
+export class ChartShortcutsDialogProps extends DialogProps {
+}
+
+@injectable()
+export class ChartShortcutsDialog extends ReactDialog<void> {
+
+    constructor(
+        @inject(ChartShortcutsDialogProps) protected readonly props: ChartShortcutsDialogProps
+    ) {
+        super({
+            title: 'Trace Viewer Keyboard and Mouse Shortcuts',
+        });
+        this.appendAcceptButton(Dialog.OK);
+    }
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.title.label = 'Trace Viewer Keyboard and Mouse Shortcuts';
+        this.update();
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className="shortcuts-table">
+                <EssentialShortcutsTable />
+                <ZoomPanShortcutsTable />
+                <TimeGraphShortcutsTable />
+                <SelectShortcutsTable />
+            </div>
+        );
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.update();
+    }
+
+    get value(): undefined { return undefined; }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/essential-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/essential-shortcuts-table.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export class EssentialShortcutsTable extends React.Component {
+
+    render(): React.ReactNode {
+        return <React.Fragment>
+            <span className='shortcuts-table-header'>ESSENTIAL</span>
+            <div className='shortcuts-table-row'>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><i className='fa fa-question-circle fa-lg' /> Display This Menu</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>CTRL / command</span>
+                                    <span className='monaco-keybinding-key'>F1</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className='shortcuts-table-column'>
+                    <table></table>
+                </div>
+            </div>
+        </React.Fragment>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/select-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/select-shortcuts-table.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+export class SelectShortcutsTable extends React.Component {
+
+    render(): React.ReactNode {
+        return <React.Fragment>
+            <span className='shortcuts-table-header'>SELECT</span>
+            <div className='shortcuts-table-row'>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Select element</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span>Click element</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Select point in time</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span>Click anywhere in chart</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Extend time range</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Shift</span>
+                                    <span className='monaco-keybinding-key'>Click</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>Shift</span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Select time range</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Drag</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </React.Fragment>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/time-graph-navigation-shortcuts-table.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+export class TimeGraphShortcutsTable extends React.Component {
+
+    render(): React.ReactNode {
+        return <React.Fragment>
+            <span className='shortcuts-table-header'>TIME-GRAPH NAVIGATION</span>
+            <div className='shortcuts-table-row'>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Next state</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-right' /></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Previous state</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-left' /></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Zoom to state&apos;s range</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span>Double-click state</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Move up a row</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-up' /></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Move down a row</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'><i className='fa fa-arrow-down' /></span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </React.Fragment>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/zoom-pan-shortcuts-table.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/zoom-pan-shortcuts-table.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+export class ZoomPanShortcutsTable extends React.Component {
+
+    render(): React.ReactNode {
+        return <React.Fragment>
+            <span className='shortcuts-table-header'>ZOOM AND PAN</span>
+            <div className='shortcuts-table-row'>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><i className='fa fa-plus-square-o fa-lg' /> Zoom in</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>W</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>I</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>CTRL</span>
+                                    <span className='monaco-keybinding-key'>Scroll</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>+</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><i className='fa fa-minus-square-o fa-lg' /> Zoom out</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>S</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>K</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>CTRL</span>
+                                    <span className='monaco-keybinding-key'>Scroll</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>-</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><i className='fa fa-hand-paper-o fa-lg' /> Pan</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>A</span>
+                                    <span className='monaco-keybinding-seperator'>&</span>
+                                    <span className='monaco-keybinding-key'>D</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>J</span>
+                                    <span className='monaco-keybinding-seperator'>&</span>
+                                    <span className='monaco-keybinding-key'>L</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>CTRL</span>
+                                    <span className='monaco-keybinding-key'>Drag</span>
+                                    <span className='monaco-keybinding-seperator'>or</span>
+                                    <span className='monaco-keybinding-key'>Middle-Drag</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className='shortcuts-table-column'>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>Zoom to selected range</td>
+                                <td className='monaco-keybinding shortcuts-table-keybinding'>
+                                    <span className='monaco-keybinding-key'>Right-Click</span>
+                                    <span className='monaco-keybinding-key'>Drag</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </React.Fragment>;
+    }
+}

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-commands.ts
@@ -20,3 +20,7 @@ export const StopServerCommand: Command = {
     label: 'Stop Trace Server'
 };
 
+export const KeyboardShortcutsCommand: Command = {
+    id: 'trace-viewer-keyboard-shortcuts',
+    label: 'Trace Viewer Keyboard and Mouse Shortcuts'
+};

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-contribution.ts
@@ -1,22 +1,23 @@
 import { injectable, inject } from 'inversify';
 import { CommandRegistry, CommandContribution, MessageService } from '@theia/core';
-import { WidgetOpenerOptions, WidgetOpenHandler } from '@theia/core/lib/browser';
+import { WidgetOpenerOptions, WidgetOpenHandler, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import { OpenTraceCommand, StartServerCommand, StopServerCommand, TraceViewerCommand } from './trace-viewer-commands';
+import { OpenTraceCommand, StartServerCommand, StopServerCommand, TraceViewerCommand, KeyboardShortcutsCommand } from './trace-viewer-commands';
 import { PortBusy, TraceServerConfigService } from '../../common/trace-server-config';
 import { TracePreferences, TRACE_PATH, TRACE_PORT } from '../trace-server-preference';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import { TspClientProvider } from '../tsp-client-provider-impl';
+import { ChartShortcutsDialog } from './../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 
 interface TraceViewerWidgetOpenerOptions extends WidgetOpenerOptions {
     traceUUID: string;
 }
 
 @injectable()
-export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget> implements CommandContribution {
+export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget> implements CommandContribution, KeybindingContribution {
 
     private tspClient: TspClient;
 
@@ -33,6 +34,7 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
     @inject(TracePreferences) protected tracePreferences: TracePreferences;
     @inject(TraceServerConfigService) protected readonly traceServerConfigService: TraceServerConfigService;
     @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(ChartShortcutsDialog) protected readonly chartShortcuts: ChartShortcutsDialog;
 
     readonly id = TraceViewerWidget.ID;
     readonly label = 'Trace Viewer';
@@ -133,6 +135,13 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
         throw new Error('Could not open TraceViewerWidget');
     }
 
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            keybinding: 'ctrlcmd+f1',
+            command: KeyboardShortcutsCommand.id,
+        });
+    }
+
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(OpenTraceCommand, {
             execute: () => this.launchTraceServer()
@@ -168,6 +177,11 @@ export class TraceViewerContribution extends WidgetOpenHandler<TraceViewerWidget
                 } catch (err) {
                     this.messageService.error(`Failed to stop the trace server on port: ${this.port}.`);
                 }
+            }
+        });
+        registry.registerCommand(KeyboardShortcutsCommand, {
+            execute: () => {
+                this.chartShortcuts.open();
             }
         });
     }

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-frontend-module.ts
@@ -1,5 +1,5 @@
 import { ContainerModule, Container } from 'inversify';
-import { WidgetFactory, OpenHandler, FrontendApplicationContribution, bindViewContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { WidgetFactory, OpenHandler, FrontendApplicationContribution, bindViewContribution, WebSocketConnectionProvider, KeybindingContribution } from '@theia/core/lib/browser';
 import { TraceViewerWidget, TraceViewerWidgetOptions } from './trace-viewer';
 import { TraceViewerContribution } from './trace-viewer-contribution';
 import { TraceServerUrlProvider } from '../../common/trace-server-url-provider';
@@ -20,6 +20,7 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 import { TraceViewerToolbarContribution } from './trace-viewer-toolbar-contribution';
 import { LazyTspClientFactory } from 'traceviewer-base/lib/lazy-tsp-client';
 import { BackendFileService, backendFileServicePath } from '../../common/backend-file-service';
+import { ChartShortcutsDialog, ChartShortcutsDialogProps } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 
 export default new ContainerModule(bind => {
     bind(TraceServerUrlProviderImpl).toSelf().inSingletonScope();
@@ -27,6 +28,8 @@ export default new ContainerModule(bind => {
     bind(TraceServerUrlProvider).toService(TraceServerUrlProviderImpl);
     bind(LazyTspClientFactory).toFunction(LazyTspClientFactory);
     bind(TspClientProvider).toSelf().inSingletonScope();
+    bind(ChartShortcutsDialog).toSelf().inSingletonScope();
+    bind(ChartShortcutsDialogProps).toConstantValue({ title: 'Trace Viewer Keyboard and Mouse Shortcuts' });
     bind(TheiaMessageManager).toSelf().inSingletonScope();
 
     bind(TraceViewerToolbarContribution).toSelf().inSingletonScope();
@@ -46,7 +49,7 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(TraceViewerContribution).toSelf().inSingletonScope();
-    [CommandContribution, OpenHandler, FrontendApplicationContribution].forEach(serviceIdentifier =>
+    [CommandContribution, OpenHandler, FrontendApplicationContribution, KeybindingContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(TraceViewerContribution)
     );
 

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
@@ -36,6 +36,12 @@ export namespace TraceViewerToolbarCommands {
         label: 'Open Trace',
         iconClass: 'fa fa-folder-open-o fa-lg',
     };
+
+    export const CHARTS_CHEATSHEET: Command = {
+        id: 'trace.viewer.toolbar.cheatsheet',
+        label: 'Keyboard Shortcuts (CTRL / command + F1)',
+        iconClass: 'fa fa-info-circle fa-lg',
+    };
 }
 
 export namespace TraceViewerToolbarMenus {

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-contribution.tsx
@@ -8,19 +8,16 @@ import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-mana
 import { TraceViewerWidget } from './trace-viewer';
 import { TspClientProvider } from '../tsp-client-provider-impl';
 import { ContextMenuRenderer } from '@theia/core/lib/browser';
-import { TraceExplorerOpenedTracesWidget } from '../trace-explorer/trace-explorer-sub-widgets/theia-trace-explorer-opened-traces-widget';
-import { OpenTraceCommand } from './trace-viewer-commands';
+import { ChartShortcutsDialog  } from '../trace-explorer/trace-explorer-sub-widgets/trace-explorer-keyboard-shortcuts/charts-cheatsheet-component';
 
 @injectable()
 export class TraceViewerToolbarContribution implements TabBarToolbarContribution, CommandContribution {
     @inject(ApplicationShell) protected readonly shell: ApplicationShell;
     @inject(ContextMenuRenderer) protected readonly contextMenuRenderer!: ContextMenuRenderer;
     @inject(TspClientProvider) protected readonly tspClientProvider!: TspClientProvider;
-    @inject(MenuModelRegistry)
-    protected readonly menus: MenuModelRegistry;
-
-    @inject(CommandRegistry)
-    protected readonly commands: CommandRegistry;
+    @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry;
+    @inject(CommandRegistry) protected readonly commands: CommandRegistry;
+    @inject(ChartShortcutsDialog) protected readonly chartShortcuts: ChartShortcutsDialog;
 
     private onMarkerCategoriesFetchedSignal = () => this.doHandleMarkerCategoriesFetchedSignal();
     private onMarkerSetsFetchedSignal = () => this.doHandleMarkerSetsFetchedSignal();
@@ -83,15 +80,16 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             }
         });
         registry.registerCommand(
-            TraceViewerToolbarCommands.OPEN_TRACE, {
+            TraceViewerToolbarCommands.CHARTS_CHEATSHEET, {
             isVisible: (w: Widget) => {
-                if (w instanceof TraceExplorerOpenedTracesWidget) {
-                    return true;
+                if (w instanceof TraceViewerWidget) {
+                    const traceWidget = w as TraceViewerWidget;
+                    return traceWidget.isTimeRelatedChartOpened();
                 }
                 return false;
             },
-            execute: async () => {
-                await registry.executeCommand(OpenTraceCommand.id);
+            execute: () => {
+                this.chartShortcuts.open();
             }
         });
     }
@@ -214,10 +212,10 @@ export class TraceViewerToolbarContribution implements TabBarToolbarContribution
             onDidChange: this.onMakerSetsChangedEvent,
         });
         registry.registerItem({
-            id: TraceViewerToolbarCommands.OPEN_TRACE.id,
-            command: TraceViewerToolbarCommands.OPEN_TRACE.id,
-            tooltip: TraceViewerToolbarCommands.OPEN_TRACE.label,
-            priority: 6,
+            id: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.id,
+            command: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.id,
+            tooltip: TraceViewerToolbarCommands.CHARTS_CHEATSHEET.label,
+            priority: 7,
         });
     }
 }


### PR DESCRIPTION
'Trace Viewer Keyboard and Mouse Shortcuts' dialog:
<img width="1046" alt="Screen Shot 2022-01-18 at 1 42 18 PM" src="https://user-images.githubusercontent.com/92893187/150007312-788eea33-183b-4efe-9f8d-0e734143a558.png">
<img width="423" alt="Screen Shot 2022-01-18 at 1 43 20 PM" src="https://user-images.githubusercontent.com/92893187/150007463-ed6a4d33-2cff-4a3e-8db4-31e2e68a1202.png">

Dialog can be triggered by:
1) Clicking info icon that appears in toolbar when a time-graph or xy-chart is opened:
<img width="253" alt="Screen Shot 2022-01-18 at 1 44 27 PM" src="https://user-images.githubusercontent.com/92893187/150007642-487e8393-d2ba-4939-84a6-3a6a80835aa0.png">

2) Using Theia's 'find command' search:
<img width="698" alt="Screen Shot 2022-01-18 at 1 45 18 PM" src="https://user-images.githubusercontent.com/92893187/150007778-bf7c007c-23ec-40f4-a7e1-0f56bfff6e5a.png">

3) Using keybinding 'CTRL/command + F1'
