### PR TITLE
Data Tree: Add "analysis failed" and "no results" messages

### DIFF
--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -111,11 +111,11 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     private renderMainOutputContainer(): React.ReactNode {
         if (this.state.outputStatus === ResponseStatus.FAILED) {
-            return this.analysisFailedMessage();
+            return this.renderAnalysisFailed();
         }
 
         if (this.state.outputStatus === ResponseStatus.COMPLETED && this.resultsAreEmpty()) {
-            return this.emptyResultsMessage();
+            return this.renderEmptyResults();
         }
 
         return this.renderMainArea();
@@ -125,7 +125,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
 
     abstract resultsAreEmpty(): boolean;
 
-    protected analysisFailedMessage(): React.ReactFragment {
+    protected renderAnalysisFailed(): React.ReactFragment {
         return <React.Fragment>
             <div className='message-main-area'>
                 Trace analysis failed.
@@ -133,7 +133,7 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         </React.Fragment>;
     }
 
-    protected emptyResultsMessage(): React.ReactFragment {
+    protected renderEmptyResults(): React.ReactFragment {
         return <React.Fragment>
                 <div className='message-main-area'>
                     Trace analysis complete.

--- a/packages/react-components/src/components/abstract-output-component.tsx
+++ b/packages/react-components/src/components/abstract-output-component.tsx
@@ -9,6 +9,7 @@ import { OutputComponentStyle } from './utils/output-component-style';
 import { OutputStyleModel } from 'tsp-typescript-client/lib/models/styles';
 import { TooltipComponent } from './tooltip-component';
 import { TooltipXYComponent } from './tooltip-xy-component';
+import { ResponseStatus } from 'tsp-typescript-client/lib/models/response/responses';
 
 export interface AbstractOutputProps {
     tspClient: TspClient;
@@ -49,11 +50,11 @@ export interface AbstractOutputState {
 
 export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S extends AbstractOutputState> extends React.Component<P, S> {
 
-    private mainAreaContainer: React.RefObject<HTMLDivElement>;
+    private mainOutputContainer: React.RefObject<HTMLDivElement>;
 
     constructor(props: P) {
         super(props);
-        this.mainAreaContainer = React.createRef();
+        this.mainOutputContainer = React.createRef();
         this.closeComponent = this.closeComponent.bind(this);
         this.renderTitleBar = this.renderTitleBar.bind(this);
     }
@@ -73,9 +74,9 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
             <div className='widget-handle' style={{ width: this.props.style.handleWidth, height: this.props.style.height }}>
                 {this.renderTitleBar()}
             </div>
-            <div className='main-output-container' ref={this.mainAreaContainer}
+            <div className='main-output-container' ref={this.mainOutputContainer}
                 style={{ width: this.props.widthWPBugWorkaround - this.props.style.handleWidth, height: this.props.style.height }}>
-                {this.renderMainArea()}
+                {this.renderMainOutputContainer()}
             </div>
             {this.props.children}
         </div>;
@@ -98,8 +99,8 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
     }
 
     public getMainAreaWidth(): number {
-        if (this.mainAreaContainer.current) {
-            return this.mainAreaContainer.current.clientWidth;
+        if (this.mainOutputContainer.current) {
+            return this.mainOutputContainer.current.clientWidth;
         }
         return this.props.widthWPBugWorkaround - this.props.style.handleWidth;
     }
@@ -108,7 +109,21 @@ export abstract class AbstractOutputComponent<P extends AbstractOutputProps, S e
         return this.props.style.handleWidth;
     }
 
+    private renderMainOutputContainer(): React.ReactNode {
+        if (this.state.outputStatus === ResponseStatus.FAILED) {
+            return this.analysisFailedMessage();
+        }
+
+        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.resultsAreEmpty()) {
+            return this.emptyResultsMessage();
+        }
+
+        return this.renderMainArea();
+    }
+
     abstract renderMainArea(): React.ReactNode;
+
+    abstract resultsAreEmpty(): boolean;
 
     protected analysisFailedMessage(): React.ReactFragment {
         return <React.Fragment>

--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -15,14 +15,6 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
     }
 
     renderMainArea(): React.ReactNode {
-        if (this.state.outputStatus === ResponseStatus.FAILED) {
-            return this.analysisFailedMessage();
-        }
-
-        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.resultsAreEmpty()) {
-            return this.emptyResultsMessage();
-        }
-
         return <React.Fragment>
             <div ref={this.treeRef} className='output-component-tree'
                 style={{ width: this.getTreeWidth(), height: this.props.style.height }}

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -73,6 +73,10 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
         return ResponseStatus.FAILED;
     }
 
+    resultsAreEmpty(): boolean {
+        return this.state.xyTree.length === 0;
+    }
+
     renderTree(): React.ReactNode | undefined {
         this.onToggleCollapse = this.onToggleCollapse.bind(this);
         this.onOrderChange = this.onOrderChange.bind(this);

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -60,9 +60,16 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
                     xyTree: treeResponse.model.entries,
                     columns
                 });
+            } else {
+                this.setState({
+                    outputStatus: treeResponse.status
+                });
             }
             return treeResponse.status;
         }
+        this.setState({
+            outputStatus: ResponseStatus.FAILED
+        });
         return ResponseStatus.FAILED;
     }
 

--- a/packages/react-components/src/components/null-output-component.tsx
+++ b/packages/react-components/src/components/null-output-component.tsx
@@ -25,4 +25,8 @@ export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps
             </div>
         </React.Fragment>;
     }
+
+    resultsAreEmpty(): boolean {
+        return true;
+    }
   }

--- a/packages/react-components/src/components/table-output-component.tsx
+++ b/packages/react-components/src/components/table-output-component.tsx
@@ -97,14 +97,6 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
     }
 
     renderMainArea(): React.ReactNode {
-        if (this.state.outputStatus === ResponseStatus.FAILED) {
-            return this.analysisFailedMessage();
-        }
-
-        if (this.state.outputStatus === ResponseStatus.COMPLETED && this.state.tableColumns.length === 0) {
-            return this.emptyResultsMessage();
-        }
-
         return <div id='events-table'
             className={this.props.backgroundTheme === 'light' ? 'ag-theme-balham' : 'ag-theme-balham-dark'}
             style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}>
@@ -125,6 +117,10 @@ export class TableOutputComponent extends AbstractOutputComponent<TableOutputPro
             >
             </AgGridReact>
         </div>;
+    }
+
+    resultsAreEmpty(): boolean {
+        return this.state.tableColumns.length === 0;
     }
 
     componentDidMount(): void {


### PR DESCRIPTION
Messages are now handled in the abstract output component so less code is required in each output component.

When error messages are handled in each component rather (than by the
parent class), it is easy to forget to handle these errors when
implementing new output components. Handling errors in the parent class
makes these bugs less likely.

"No results" message: Instead of needing to remember to call the
function in each output components the abstract class structure imposes
that every output component implement a check for empty results (and
displaying the message is handled by the parent class).

Analysis failed message: The developper still needs to remember to set
the output status to failed when implementing new output components.
This change does not help with remembering to do that.

Signed-off-by: Erica Bugden <erica.bugden@gmail.com>