### PR TITLE
Selecting device names/labels shoudn't be allowed

### DIFF
--- a/packages/react-components/src/components/abstract-tree-output-component.tsx
+++ b/packages/react-components/src/components/abstract-tree-output-component.tsx
@@ -16,7 +16,7 @@ export abstract class AbstractTreeOutputComponent<P extends AbstractOutputProps,
 
     renderMainArea(): React.ReactNode {
         return <React.Fragment>
-            <div ref={this.treeRef} className='output-component-tree'
+            <div ref={this.treeRef} className='output-component-tree disable-select'
                 style={{ width: this.getTreeWidth(), height: this.props.style.height }}
             >
                 {this.renderTree()}

--- a/packages/react-components/src/components/datatree-output-component.tsx
+++ b/packages/react-components/src/components/datatree-output-component.tsx
@@ -97,7 +97,7 @@ export class DataTreeOutputComponent extends AbstractOutputComponent<AbstractOut
     renderMainArea(): React.ReactNode {
         return <React.Fragment>
             {this.state.outputStatus === ResponseStatus.COMPLETED ?
-                <div ref={this.treeRef} className='output-component-tree'
+                <div ref={this.treeRef} className='output-component-tree disable-select'
                     style={{ height: this.props.style.height, width: this.props.widthWPBugWorkaround }}
                 >
                     {this.renderTree()}

--- a/packages/react-components/src/components/null-output-component.tsx
+++ b/packages/react-components/src/components/null-output-component.tsx
@@ -15,7 +15,7 @@ export class NullOutputComponent extends AbstractOutputComponent<NullOutputProps
         const treeWidth = Math.min(this.getMainAreaWidth(), this.props.style.sashOffset + this.props.style.sashWidth);
         const chartWidth = this.getMainAreaWidth() - treeWidth;
         return <React.Fragment>
-            <div className='output-component-tree'
+            <div className='output-component-tree disable-select'
                 style={{ width: treeWidth, height: this.props.style.height }}
             >
                 {''}

--- a/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
+++ b/packages/react-components/src/trace-explorer/trace-explorer-views-widget.tsx
@@ -58,7 +58,7 @@ export class ReactAvailableViewsWidget extends React.Component<ReactAvailableVie
         const totalHeight = this.getTotalHeight();
         return (
             <div className='trace-explorer-views'>
-                <div className='trace-explorer-panel-content'>
+                <div className='trace-explorer-panel-content disable-select'>
                     <AutoSizer>
                         {({ width }) =>
                             <List

--- a/packages/react-components/style/output-components-style.css
+++ b/packages/react-components/style/output-components-style.css
@@ -40,6 +40,13 @@
     overflow: hidden;
 }
 
+.disable-select {
+    -webkit-user-select: none;  
+    -moz-user-select: none;    
+    -ms-user-select: none;      
+    user-select: none;
+}
+
 .output-component-tree {
     white-space: pre-wrap;
 }


### PR DESCRIPTION
**Current Behavior**: Labels in trace viewer and trace explorer can be selected with mouse.

**Expected Behavior**: Selecting the text in trace viewer and trace explorer (other than tooltip) should be restricted. Current behavior doesn't have good UX

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>