### PR TITLE
Remove context menu from TraceContextComponent

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -293,8 +293,13 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         }));
     }
 
+    private onContextMenu(event: React.MouseEvent) {
+        event.preventDefault();
+    }
+
     render(): JSX.Element {
         return <div className='trace-context-container'
+            onContextMenu={event => this.onContextMenu(event)}
             onKeyDown={event => this.onKeyDown(event)}
             ref={this.traceContextContainer}>
             <TooltipComponent ref={this.tooltipComponent} />


### PR DESCRIPTION
Disabled the browser's context-menu for the entire TraceContextComponent, which effects the area highlighted in blue:

![PreventDefaultContextMenu](https://user-images.githubusercontent.com/98342456/152235638-4b22cbd0-ad12-4bb0-8841-29858c8b6e01.PNG)

There are still areas in the extension where we can access the browser's context-menu: 

- Empty space under "Opened Traces"
- Empty space under "Item Properties"
- Empty space next to Trace Tabs (near top)

If we want the right-click disabled there too, we can move this to a higher-level component.

Fixes: #634, #635

Signed-off-by: William Yang william.yang@ericsson.com