### PR TITLE
Launch: adjust the Jest-based configuration(s) running tests in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -111,10 +111,11 @@
             "request": "launch",
             "name": "Jest Current File",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "cwd": "${workspaceFolder}/packages/react-components",
             "args": [
                 "${fileBasenameNoExtension}",
                 "--config",
-                "viewer-prototype/jest.config.json"
+                "jest.config.json"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -123,6 +123,16 @@
             "windows": {
                 "program": "${workspaceFolder}/node_modules/jest/bin/jest"
             }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All Tests",
+            "runtimeExecutable": "yarn",
+            "program": "test",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
         }
     ]
 }


### PR DESCRIPTION
- This PR starts with fixing the existing launch configuration that runs specific tests.
- Follows a second commit that adds a new launcher, this time to run every Jest test.
- Each commit has a message listing the steps for how to test these.