### PR TITLE
Split X-axis views and non-X-axis views

### DIFF
--- a/packages/react-components/src/components/trace-context-component.tsx
+++ b/packages/react-components/src/components/trace-context-component.tsx
@@ -26,6 +26,7 @@ import { TooltipComponent } from './tooltip-component';
 import { TooltipXYComponent } from './tooltip-xy-component';
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
 import { DataTreeOutputComponent } from './datatree-output-component';
+import { cloneDeep } from 'lodash';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -69,6 +70,8 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     private tooltipComponent: React.RefObject<TooltipComponent>;
     private tooltipXYComponent: React.RefObject<TooltipXYComponent>;
     private traceContextContainer: React.RefObject<HTMLDivElement>;
+    private _storedTimescaleLayout: Layout[] = [];
+    private _storedNonTimescaleLayout: Layout[] = [];
 
     protected widgetResizeHandlers: (() => void)[] = [];
     protected readonly addWidgetResizeHandler = (h: () => void): void => {
@@ -134,6 +137,7 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         this.traceContextContainer = React.createRef();
         this.onResize = this.onResize.bind(this);
         this.setChartOffset = this.setChartOffset.bind(this);
+        this.onLayoutChange = this.onLayoutChange.bind(this);
         this.props.addResizeHandler(this.onResize);
         this.initialize();
         this.subscribeToEvents();
@@ -291,6 +295,17 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         event.preventDefault();
     }
 
+    private onLayoutChange(currentLayout: Layout[]): void {
+        if (currentLayout.length > 0) {
+            const curLayoutCopy = cloneDeep(currentLayout);
+            if (this._storedTimescaleLayout.find(obj => obj.i === currentLayout[0].i)) {
+                this._storedTimescaleLayout = curLayoutCopy;
+            } else {
+                this._storedNonTimescaleLayout = curLayoutCopy;
+            }
+        }
+    }
+
     render(): JSX.Element {
         return <div className='trace-context-container'
             onContextMenu={event => this.onContextMenu(event)}
@@ -318,69 +333,91 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
     }
 
     private renderOutputs() {
-        const layouts = this.generateGridLayout();
-        const outputs = this.props.outputs;
-        const showTimeScale = outputs.filter(output => output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY').length > 0;
+        this.generateGridLayout();
         const chartWidth = Math.max(0, this.state.style.width - this.state.style.chartOffset);
-        return <React.Fragment>
-            {showTimeScale &&
-                <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
-                    <TimeAxisComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
-                        addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
-                </div>
+
+        const timeScaleCharts: Array<OutputDescriptor> = [];
+        const nonTimeScaleCharts: Array<OutputDescriptor> = [];
+
+        for (const output of this.props.outputs) {
+            if (output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY') {
+                timeScaleCharts.push(output);
+            } else {
+                nonTimeScaleCharts.push(output);
             }
+        }
+
+        return <React.Fragment>
             {
                 // Syntax to use ReactGridLayout with Custom Components, while passing resized dimensions to children:
                 // https://github.com/STRML/react-grid-layout/issues/299#issuecomment-524959229
             }
-            <ResponsiveGridLayout className='outputs-grid-layout' margin={[0, 5]} isResizable={true} isDraggable={true} resizeHandles={['se', 's', 'sw']}
-                layouts={{ lg: layouts }} cols={{ lg: 1 }} breakpoints={{ lg: 1200 }} rowHeight={this.DEFAULT_COMPONENT_ROWHEIGHT} draggableHandle={'.title-bar-label'}>
-                {outputs.map(output => {
-                    const responseType = output.type;
-                    const outputProps: AbstractOutputProps = {
-                        tspClient: this.props.tspClient,
-                        tooltipComponent: this.tooltipComponent.current,
-                        tooltipXYComponent: this.tooltipXYComponent.current,
-                        traceId: this.state.experiment.UUID,
-                        outputDescriptor: output,
-                        markerCategories: this.props.markerCategoriesMap.get(output.id),
-                        markerSetId: this.props.markerSetId,
-                        range: this.state.currentRange,
-                        nbEvents: this.state.experiment.nbEvents,
-                        viewRange: this.state.currentViewRange,
-                        selectionRange: this.state.currentTimeSelection,
-                        style: this.state.style,
-                        onOutputRemove: this.props.onOutputRemove,
-                        unitController: this.unitController,
-                        outputWidth: this.state.style.width,
-                        backgroundTheme: this.state.backgroundTheme,
-                        setChartOffset: this.setChartOffset
-                    };
-                    switch (responseType) {
-                        case 'TIME_GRAPH':
-                            return <TimegraphOutputComponent key={output.id} {...outputProps}
-                                addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />;
-                        case 'TREE_TIME_XY':
-                            return <XYOutputComponent key={output.id} {...outputProps} />;
-                        case 'TABLE':
-                            return <TableOutputComponent key={output.id} {...outputProps} />;
-                        case 'DATA_TREE':
-                            return <DataTreeOutputComponent key={output.id} {...outputProps} />;
-                        default:
-                            return <NullOutputComponent key={output.id} {...outputProps} />;
-                    }
-                })}
-            </ResponsiveGridLayout>
-            {showTimeScale &&
-                <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
-                    <TimeNavigatorComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
-                        addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
-                </div>
+            <div style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING, visibility: timeScaleCharts.length ? 'visible' : 'hidden' }}>
+                <TimeAxisComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
+                    addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
+             </div>
+            <div className='outputs-grid-layout'>
+            {timeScaleCharts.length > 0 &&
+                <>
+                    {this.renderGridLayout(timeScaleCharts, this._storedTimescaleLayout)}
+                    <div className='sticky-div' style={{ marginLeft: this.state.style.chartOffset, marginRight: this.SCROLLBAR_PADDING }}>
+                        <TimeNavigatorComponent unitController={this.unitController} style={{ ...this.state.style, width: chartWidth }}
+                            addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />
+                    </div>
+                </>
             }
+            {nonTimeScaleCharts.length > 0 &&
+                this.renderGridLayout(nonTimeScaleCharts, this._storedNonTimescaleLayout)
+            }
+            </div>
         </React.Fragment>;
     }
 
+    private renderGridLayout(outputs: OutputDescriptor[], layout: Layout[]) {
+        return <ResponsiveGridLayout margin={[0, 5]} isResizable={true} isDraggable={true} resizeHandles={['se', 's', 'sw']}
+        onLayoutChange={this.onLayoutChange} layouts={{ lg: layout }} cols={{ lg: 1 }} breakpoints={{ lg: 1200 }} rowHeight={this.DEFAULT_COMPONENT_ROWHEIGHT}
+        draggableHandle={'.title-bar-label'}>
+            {outputs.map(output => {
+                const responseType = output.type;
+                const outputProps: AbstractOutputProps = {
+                    tspClient: this.props.tspClient,
+                    tooltipComponent: this.tooltipComponent.current,
+                    tooltipXYComponent: this.tooltipXYComponent.current,
+                    traceId: this.state.experiment.UUID,
+                    outputDescriptor: output,
+                    markerCategories: this.props.markerCategoriesMap.get(output.id),
+                    markerSetId: this.props.markerSetId,
+                    range: this.state.currentRange,
+                    nbEvents: this.state.experiment.nbEvents,
+                    viewRange: this.state.currentViewRange,
+                    selectionRange: this.state.currentTimeSelection,
+                    style: this.state.style,
+                    onOutputRemove: this.props.onOutputRemove,
+                    unitController: this.unitController,
+                    outputWidth: this.state.style.width,
+                    backgroundTheme: this.state.backgroundTheme,
+                    setChartOffset: this.setChartOffset
+                };
+                switch (responseType) {
+                    case 'TIME_GRAPH':
+                        return <TimegraphOutputComponent key={output.id} {...outputProps}
+                            addWidgetResizeHandler={this.addWidgetResizeHandler} removeWidgetResizeHandler={this.removeWidgetResizeHandler} />;
+                    case 'TREE_TIME_XY':
+                        return <XYOutputComponent key={output.id} {...outputProps} />;
+                    case 'TABLE':
+                        return <TableOutputComponent key={output.id} {...outputProps} />;
+                    case 'DATA_TREE':
+                        return <DataTreeOutputComponent key={output.id} {...outputProps} />;
+                    default:
+                        return <NullOutputComponent key={output.id} {...outputProps} />;
+                }
+            })}
+        </ResponsiveGridLayout>;
+    }
+
     private renderPlaceHolder() {
+        this._storedTimescaleLayout = [];
+        this._storedNonTimescaleLayout = [];
         return <div className='no-output-placeholder'>
             {'Trace loaded successfully.'}
             <br />
@@ -388,21 +425,54 @@ export class TraceContextComponent extends React.Component<TraceContextProps, Tr
         </div>;
     }
 
-    private generateGridLayout(): Layout[] {
-        const outputs = this.props.outputs;
-        const layouts: Layout[] = [];
-        if (outputs.length) {
-            outputs.forEach((output, index) => {
-                const itemLayout = {
+    private generateGridLayout(): void {
+        let existingTimeScaleLayouts: Array<Layout> = [];
+        let existingNonTimeScaleLayouts: Array<Layout> = [];
+        const newTimeScaleLayouts: Array<Layout> = [];
+        const newNonTimeScaleLayouts: Array<Layout> = [];
+
+        for (const output of this.props.outputs) {
+            const curChartTimeLine = this._storedTimescaleLayout.find(layout => layout.i === output.id);
+            const curChartNonTimeLine = this._storedNonTimescaleLayout.find(layout => layout.i === output.id);
+
+            if (curChartTimeLine) {
+                existingTimeScaleLayouts.push(curChartTimeLine);
+            } else if (curChartNonTimeLine) {
+                existingNonTimeScaleLayouts.push(curChartNonTimeLine);
+            } else if (output.type === 'TIME_GRAPH' || output.type === 'TREE_TIME_XY') {
+                newTimeScaleLayouts.push({
                     i: output.id,
                     x: 0,
-                    y: index,
+                    y: 1,
                     w: 1,
-                    h: this.DEFAULT_COMPONENT_HEIGHT
-                };
-                layouts.push(itemLayout);
-            });
+                    h: this.DEFAULT_COMPONENT_HEIGHT,
+                });
+            } else {
+                newNonTimeScaleLayouts.push({
+                    i: output.id,
+                    x: 0,
+                    y: 1,
+                    w: 1,
+                    h: this.DEFAULT_COMPONENT_HEIGHT,
+                });
+            }
         }
-        return layouts;
+
+        existingTimeScaleLayouts.sort((a,b) => (a.y > b.y) ? 1 : -1);
+        existingNonTimeScaleLayouts.sort((a,b) => (a.y > b.y) ? 1 : -1);
+
+        existingTimeScaleLayouts = existingTimeScaleLayouts.concat(newTimeScaleLayouts);
+        existingNonTimeScaleLayouts = existingNonTimeScaleLayouts.concat(newNonTimeScaleLayouts);
+
+        this._storedTimescaleLayout = existingTimeScaleLayouts;
+        this._storedNonTimescaleLayout = existingNonTimeScaleLayouts;
+
+        // At times after layout change RGL changes y values of existing charts from 1,2,3 to 10,20,30
+        this._storedTimescaleLayout.forEach((output, index) => {
+            output.y = index;
+        });
+        this._storedNonTimescaleLayout.forEach((output, index) => {
+            output.y = index;
+        });
     }
 }

--- a/packages/react-components/style/trace-context-style.css
+++ b/packages/react-components/style/trace-context-style.css
@@ -21,9 +21,10 @@
 }
 
 .outputs-grid-layout {
-    flex-grow: 1;
     overflow-y: scroll;
     overflow-x: hidden;
+    position: relative;
+    flex-grow: 1;
 }
 
 .react-grid-item > .react-resizable-handle {
@@ -34,4 +35,9 @@
 .react-grid-item > .react-resizable-handle::after {
     border-right-color: var(--theia-ui-font-color0) !important;
     border-bottom-color: var(--theia-ui-font-color0) !important;
+}
+
+.sticky-div {
+    position: sticky;
+    bottom: 0;
 }


### PR DESCRIPTION
Implement different visual containers for views that have an X axis and those that don't

Changes Made:
- View is arranged into charts that use the X-axis (TimeAxis & TimeNavigator components) and those that don’t.
- Sizes and orders of charts are preserved when views are added or removed
- The close button is accessible when only a single view that does not spawn the time-axis is open

Notes:
- I've added some commenting for now to explain my implementation
- I feel that the runtime is a bit high, would like some suggestions on how I could optimize

fixes #287
fixes #648
fixes #618

<img width="1437" alt="Screen Shot 2022-02-17 at 11 39 32 PM" src="https://user-images.githubusercontent.com/92893187/154624477-85d098b2-0eca-4201-b060-899307d943b2.png">

Signed-off-by: hriday-panchasara <hriday.panchasara@ericsson.com>