### PR TITLE
Update open trace icon to avoid confusion

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.17",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
+    "@vscode/codicons": "^0.0.29",
     "ag-grid-community": "^23.1.0",
     "ag-grid-react": "^23.1.0",
     "chart.js": "^2.8.0",

--- a/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
+++ b/theia-extensions/viewer-prototype/src/browser/trace-viewer/trace-viewer-toolbar-commands.ts
@@ -34,7 +34,7 @@ export namespace TraceViewerToolbarCommands {
     export const OPEN_TRACE: Command = {
         id: 'trace.viewer.openTrace',
         label: 'Open Trace',
-        iconClass: 'fa fa-folder-open-o fa-lg',
+        iconClass: 'codicon codicon-new-folder',
     };
 
     export const CHARTS_CHEATSHEET: Command = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4131,6 +4131,11 @@
   resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.28.tgz#e86b7082cb0858d036788a00b7bf87ade1921199"
   integrity sha512-p8zph8Tflh6KUirDCVOti8tr/BhngQx9Z6QXSKBJgPTZMxiKmP6eF75AKDopUeffp7X80Vdo48nv4kdW9d73Dg==
 
+"@vscode/codicons@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.29.tgz#587e6ce4be8de55d9d11e5297ea55a3dbab08ccf"
+  integrity sha512-AXhTv1nl3r4W5DqAfXXKiawQNW+tLBNlXn/GcsnFCL0j17sQ2AY+az9oB9K6wjkibq1fndNJvmT8RYN712Fdww==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
Currently, the trace extension uses the ![image](https://user-images.githubusercontent.com/92533264/153945276-909063ea-6805-4bf6-8969-13e0006b9ebf.png) icon for the open trace button. This can be confusing for users, since they can see the action as closing the current trace and opening a new one. The expected understanding of this action is opening a new trace along side the old ones. This commit updates the icon of the open trace button to ![image](https://user-images.githubusercontent.com/92533264/153945389-477dbcd3-d1ef-4580-8bc4-f53cef604f4c.png) to avoid this confusion.

Signed-off-by: Hoang Thuan Pham <hoang.pham@calian.ca>