### PR TITLE
Implement statistics for a selected area in the chart

### DIFF
--- a/packages/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/packages/react-components/src/components/utils/filter-tree/tree.tsx
@@ -6,6 +6,7 @@ import { Table } from './table';
 import { getAllExpandedNodeIds } from './utils';
 import { SortConfig, sortNodes } from './sort';
 import ColumnHeader from './column-header';
+import { isEqual } from 'lodash';
 
 interface FilterTreeProps {
     nodes: TreeNode[];
@@ -43,6 +44,8 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             sortConfig: []
         };
     }
+
+    private _filter = '';
 
     getRootNodes = (): TreeNode[] => {
         const nodes = [...this.props.nodes];
@@ -211,6 +214,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
     isCollapsed = (id: number): boolean => this.props.collapsedNodes.includes(id);
 
     handleFilterChanged = (filter: string): void => {
+        this._filter = filter;
         let filteredTree: TreeNode[] = [];
         const matchedIds: number[] = [];
         const rootNodes = this.getRootNodes();
@@ -261,8 +265,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             onSortConfigChange={this.handleSortConfigChange}
             showHeader={this.props.showHeader}
             headers={this.props.headers}
-            className={this.props.className}
-        />;
+            className={this.props.className} />;
 
     render(): JSX.Element | undefined {
         if (!this.props.nodes) { return undefined; }
@@ -277,6 +280,12 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             </React.Fragment>;
         } else {
             return <Message></Message>;
+        }
+    }
+
+    componentDidUpdate(prevProps: FilterTreeProps): void {
+        if (!isEqual(this.props.nodes, prevProps.nodes)) {
+            this.handleFilterChanged(this._filter);
         }
     }
 }


### PR DESCRIPTION
Show statistics for selected region in datatree-output-component

In the datatree-output-component, a subtree labeled 'Selection' is shown whenever there is a region selected. When no region is selected, hide the row:
![Screen Shot 2022-03-02 at 16 50 57 PM](https://user-images.githubusercontent.com/92893187/156463144-a11d7aa7-68b2-48f4-aa2e-994677d47c5c.png)
![Screen Shot 2022-03-02 at 16 51 27 PM](https://user-images.githubusercontent.com/92893187/156463147-4b42a89f-0852-4ffb-9ff2-4dd89fb7fb42.png)

