### PR TITLE
Prevent unnecessary xy requests while analysis is running

### DIFF
--- a/packages/react-components/src/components/xy-output-component.tsx
+++ b/packages/react-components/src/components/xy-output-component.tsx
@@ -164,8 +164,9 @@ export class XYOutputComponent extends AbstractTreeOutputComponent<AbstractOutpu
         const checkedSeriesChanged = this.state.checkedSeries !== prevState.checkedSeries;
         const collapsedNodesChanged = this.state.collapsedNodes !== prevState.collapsedNodes;
         const chartWidthChanged = this.props.style.width !== prevProps.style.width || this.props.style.chartOffset !== prevProps.style.chartOffset;
-        const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged;
-        if (needToUpdate || prevState.outputStatus === ResponseStatus.RUNNING) {
+        const outputStatusChanged = this.state.outputStatus !== prevState.outputStatus;
+        const needToUpdate = viewRangeChanged || checkedSeriesChanged || collapsedNodesChanged || chartWidthChanged || outputStatusChanged;
+        if (needToUpdate) {
             this.updateXY();
         }
         if (this.chartRef.current) {


### PR DESCRIPTION
In componentDidUpdate(), do not trigger a xy request if the previous
outputStatus was running, only trigger it if the outputStatus changed.
This will trigger it only once, when the analysis is completed.

Fixes #691

Signed-off-by: Patrick Tasse <patrick.tasse@ericsson.com>